### PR TITLE
Export entire pack-time process.env to main process in dev mode

### DIFF
--- a/tasks/runner.js
+++ b/tasks/runner.js
@@ -51,9 +51,9 @@ module.exports = async function (networkPath) {
   await startRendererServer()
 
   console.log(`${BLUE}Starting electron...\n  (network path: ${networkPath})\n${END}`)
-  let env = {
+  let env = Object.assign({}, process.env, {
     NODE_ENV: 'development',
     COSMOS_NETWORK: networkPath
-  }
+  })
   run('electron app/src/main/index.dev.js', BLUE, 'electron', env)
 }


### PR DESCRIPTION
Fixes #43 since the GOPATH env-var was never making it to the main process, so we were always using the default (`~/go`)