### PR TITLE
Use version from root package.json

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -9,7 +9,7 @@ let RpcClient = require('tendermint')
 let semver = require('semver')
 // this dependency is wrapped in a file as it was not possible to mock the import with jest any other way
 let event = require('event-to-promise')
-let pkg = require('../../package.json')
+let pkg = require('../../../package.json')
 let rmdir = require('../helpers/rmdir.js')
 
 let shuttingDown = false

--- a/test/unit/specs/main.spec.js
+++ b/test/unit/specs/main.spec.js
@@ -45,9 +45,10 @@ describe('Startup Process', () => {
   jest.mock(appRoot + 'node_modules/event-to-promise', () => () => Promise.resolve({
     toString: () => 'Serving on'
   }))
-  // TODO: clarify if app_version should be taken from nested package.json
-  jest.mock(root + 'app/package.json', () => ({
-    version: '0.1.1'
+
+  // uses package.json from cosmos-ui/ root.
+  jest.mock(root + 'package.json', () => ({
+    version: '0.1.0'
   }))
   tendermintMock()
 
@@ -113,7 +114,7 @@ describe('Startup Process', () => {
     it('should persist the app_version', async function () {
       expect(fs.pathExistsSync(testRoot + 'app_version')).toBe(true)
       let appVersion = fs.readFileSync(testRoot + 'app_version', 'utf8')
-      expect(appVersion).toBe('0.1.1')
+      expect(appVersion).toBe('0.1.0')
     })
   })
 

--- a/test/unit/specs/main.spec.js
+++ b/test/unit/specs/main.spec.js
@@ -265,7 +265,7 @@ describe('Startup Process', () => {
 
   describe('Update app version', function () {
     beforeAll(() => {
-      jest.mock(root + 'app/package.json', () => ({
+      jest.mock(root + 'package.json', () => ({
         version: '1.1.1'
       }))
     })


### PR DESCRIPTION
The compatibility check still uses semver, so a version change is only gonna be "incompatible" if the major version increments. Fixes #39. 