### PR TITLE
reinstate NiAppFooter

### DIFF
--- a/app/src/renderer/App.vue
+++ b/app/src/renderer/App.vue
@@ -3,7 +3,7 @@
   app-header
   #app-content
     #app-main: router-view
-    // app-footer
+    app-footer
   notifications(:notifications='notifications' theme='cosmos')
   modal-help
 </template>

--- a/app/src/renderer/components/common/AppFooter.vue
+++ b/app/src/renderer/components/common/AppFooter.vue
@@ -1,15 +1,24 @@
 <template lang='pug'>
 footer.app-footer
-  .container
-    .copyright &copy; 2017 Interchain Foundation
+  .app-footer-container(v-if='connected')
+    .afi.afi-success
+      i.material-icons done
+      span {{ lastHeader.chain_id }} (\#{{ lastHeader.height }})
+    .afi
+      i.material-icons settings_ethernet 
+      span {{ nodeIP }}
+  .app-footer-container(v-else)
+    .afi
+      i.material-icons.fa-spin rotate_right 
+      span Connecting&hellip;
 </template>
 
 <script>
-import {mapGetters} from 'vuex'
+import { mapGetters } from 'vuex'
 export default {
   name: 'app-footer',
   computed: {
-    ...mapGetters(['syncHeight', 'syncTime', 'syncing', 'numPeers'])
+    ...mapGetters(['lastHeader', 'nodeIP', 'connected'])
   }
 }
 </script>
@@ -17,14 +26,20 @@ export default {
 <style lang="stylus">
 @require '~@/styles/variables.styl'
 
-.app-footer
-  .container
-    border-top 1px solid bc
-    height 3rem
+.app-footer-container
+  border-top 1px solid bc
+  height 3rem
+  display flex
+  align-items center
+  justify-content space-between
+
+  font-label()
+  color dim
+
+  .afi
     display flex
     align-items center
-    justify-content space-between
     padding 0 1rem
-
-    color dim
+    i
+      margin-right 0.5rem
 </style>


### PR DESCRIPTION
<img width="1280" alt="screen shot 2017-11-27 at 10 50 07 am" src="https://user-images.githubusercontent.com/172531/33247372-ff06c440-d360-11e7-988b-fea734c3d17b.png">

In an earlier PR (I think the `dark-theme` one) I removed the app footer containing the copyright message. I forgot that the app footer used to contain more data by @mappum, so in PR I've redesigned it and added it back.