### PR TITLE
Revert to the older page header and toolbar padding for smaller viewports

### DIFF
--- a/app/src/renderer/components/common/NiPageHeader.vue
+++ b/app/src/renderer/components/common/NiPageHeader.vue
@@ -37,7 +37,7 @@ export default {
   flex 1
   display flex
   min-width 0 // fix truncation
-  padding 1.66rem 1rem 1rem 2rem // 1.66 to match logo
+  padding 1rem
 
   i.material-icons
     font-size 1.375 * x
@@ -59,6 +59,9 @@ export default {
 
   .ni-page-header-container
     display flex
+
+  .ni-page-header-text
+    padding 1.66rem 1rem 1rem 2rem // 1.66 to match logo
 
   .ni-page-header-menu
     display flex

--- a/app/src/renderer/components/common/NiToolBar.vue
+++ b/app/src/renderer/components/common/NiToolBar.vue
@@ -18,7 +18,6 @@ export default {
 @require '~variables'
 
 .ni-tool-bar-container
-  height 100%
   display flex
 
   .main
@@ -33,7 +32,6 @@ export default {
 
   a
     padding 1rem
-    margin-top 0.7rem
 
     user-select none
     cursor pointer
@@ -109,10 +107,13 @@ export default {
 
   .ni-tool-bar-container
     background app-bg-alpha
+    height 3rem + px
     border-top px solid bc
 
 @media screen and (min-width: 1024px)
   .ni-tool-bar-container
     .main
       justify-content flex-end
+    a
+      margin-top 0.7rem
 </style>


### PR DESCRIPTION
Some of the recent spacing improvements for large viewports were leaking to small viewports. I made them apply specifically to large viewports. Relates a bit to #181 

## Current
<img width="333" alt="screen shot 2017-12-07 at 12 48 31 pm" src="https://user-images.githubusercontent.com/172531/33697992-2220a8d0-db4d-11e7-8537-b97794957839.png">

## After PR
<img width="328" alt="screen shot 2017-12-07 at 12 47 16 pm" src="https://user-images.githubusercontent.com/172531/33698004-2841111e-db4d-11e7-8c6b-0e0b7af24709.png">
