### PR TITLE
Make sends more reliable

### DIFF
--- a/app/src/renderer/vuex/modules/wallet.js
+++ b/app/src/renderer/vuex/modules/wallet.js
@@ -83,14 +83,13 @@ export default ({ commit, node }) => {
 
       // once done, do next send in queue
       function done (err, res) {
+        commit('setSending', false)
+
         if (state.sendQueue.length > 0) {
           // do next send
           let send = state.sendQueue[0]
           commit('shiftSendQueue')
           dispatch('walletSend', send)
-        } else {
-          // no sends in queue
-          commit('setSending', false)
         }
 
         cb(err, res)

--- a/app/src/renderer/vuex/modules/wallet.js
+++ b/app/src/renderer/vuex/modules/wallet.js
@@ -99,7 +99,6 @@ export default ({ commit, node }) => {
           let send = state.sendQueue[0]
           commit('shiftSendQueue')
           dispatch('walletSend', send)
-
         } else {
           // no sends in queue
           commit('setSending', false)

--- a/test/unit/specs/PageSend.spec.js
+++ b/test/unit/specs/PageSend.spec.js
@@ -9,7 +9,10 @@ const wallet = require('renderer/vuex/modules/wallet').default({
       if (args.to.addr.indexOf('fail') !== -1) return Promise.reject('Failed on purpose')
       return Promise.resolve(null)
     },
-    postTx: () => Promise.resolve(null),
+    postTx: () => Promise.resolve({
+      check_tx: { code: 0 },
+      deliver_tx: { code: 0 }
+    }),
     sign: () => Promise.resolve(null),
     queryAccount: () => {}
   }


### PR DESCRIPTION
@ebuchman was testing out the send functionality by spamming sends, and found that the account nonce was not being properly incremented with each successive transaction, so only the first one was actually going through (even though the UI showed success). This PR ensures we see error results on tx send, ensures the account nonce properly increases as we send, and puts sends in a queue to ensure only one happens at a time.