### PR TITLE
Sign-in Fixes

### DIFF
--- a/app/src/renderer/components/wallet/PageBalances.vue
+++ b/app/src/renderer/components/wallet/PageBalances.vue
@@ -46,7 +46,7 @@ export default {
     ...mapGetters(['filters', 'wallet']),
     allDenomBalances () {
       // for denoms not in balances, add empty balance
-      let balances = this.wallet.balances
+      let balances = this.wallet.balances.slice(0)
       let hasDenom = (denom) => {
         return !!balances.filter((balance) =>
           balance.denom === denom)[0]

--- a/app/src/renderer/vuex/modules/user.js
+++ b/app/src/renderer/vuex/modules/user.js
@@ -56,7 +56,7 @@ export default ({ commit, node }) => {
           new_passphrase: password
         })
       } catch (err) {
-        commit('notifyError', { title: `Couldn't login to '${account}'`, body: err.message })
+        throw Error('Incorrect passphrase')
       }
     },
     // to create a temporary seed phrase, we create a junk account with name 'trunk' for now

--- a/app/src/renderer/vuex/modules/wallet.js
+++ b/app/src/renderer/vuex/modules/wallet.js
@@ -70,7 +70,7 @@ export default ({ commit, node }) => {
       if (!res) return
       commit('setWalletHistory', res)
     },
-    async walletSend ({ state, dispatch, commit }, args) {
+    async walletSend ({ state, dispatch, commit, rootState }, args) {
       // wait until the current send operation is done
       if (state.sending) {
         commit('queueSend', args)
@@ -111,15 +111,15 @@ export default ({ commit, node }) => {
         }
         let tx = await node.buildSend(args)
         let signedTx = await node.sign({
-          name: KEY_NAME,
-          password: KEY_PASSWORD,
+          name: rootState.user.account,
+          password: rootState.user.password,
           tx
         })
         let res = await node.postTx(signedTx)
         // check response code
-        if (res.check_tx.code !== 0 || res.deliver_tx.code !== 0) {
+        if (res.check_tx.code || res.deliver_tx.code) {
           let message = res.check_tx.log || res.deliver_tx.log
-          return done(new Error('Error sending tx: ' + message))
+          return done(new Error('Error sending transaction: ' + message))
         }
 
         commit('setWalletSequence', args.sequence)

--- a/app/src/renderer/vuex/modules/wallet.js
+++ b/app/src/renderer/vuex/modules/wallet.js
@@ -48,6 +48,7 @@ export default ({ commit, node }) => {
   let actions = {
     initializeWallet ({ commit, dispatch }, key) {
       commit('setWalletKey', key)
+      dispatch('loadDenoms')
       dispatch('queryWalletState')
     },
     queryWalletState ({ state, dispatch }) {

--- a/test/unit/specs/PageSend.spec.js
+++ b/test/unit/specs/PageSend.spec.js
@@ -31,7 +31,13 @@ describe('PageSend', () => {
         wallet: () => wallet.state
       },
       modules: {
-        wallet
+        wallet,
+        user: {
+          state: {
+            account: 'default',
+            password: '1234567890'
+          }
+        }
       }
     })
     wrapper = mount(PageSend, {


### PR DESCRIPTION
Fixed a few issues introduced by the sign-in flow changes:

- Previously, when the user entered an incorrect sign-in password, we still advanced them to the app (even though a notification showed an error). Now it shows "Incorrect passphrase" and keeps the user on the sign-in page
- We weren't loading the default denoms anymore, now it does again
- The send page was still using the old account/password, now it uses the account selected at startup