### PR TITLE
updated notifications from 1.4.0 -> 1.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@nylira/vue-field": "1.1.12",
     "@nylira/vue-form-msg": "^1.0.3",
     "@nylira/vue-input": "^3.2.0",
-    "@nylira/vue-notifications": "^1.4.0",
+    "@nylira/vue-notifications": "^1.4.4",
     "axios": "^0.17.0",
     "babel-jest": "^21.2.0",
     "chart.js": "^2.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,9 +22,9 @@
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@nylira/vue-input/-/vue-input-3.4.0.tgz#741346ce0613b831b756fccb253731015fa5c246"
 
-"@nylira/vue-notifications@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@nylira/vue-notifications/-/vue-notifications-1.4.0.tgz#af51a832f3f5ccae99bdc382d0746659da72e37a"
+"@nylira/vue-notifications@^1.4.4":
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/@nylira/vue-notifications/-/vue-notifications-1.4.4.tgz#8ef4d3bbdbcbdf5570feaf17afd45c83c43d5496"
 
 "@types/node@^7.0.18":
   version "7.0.48"


### PR DESCRIPTION
This change simplifies/improves notification design. It also increases the z-index of notifications to 2000 so that it shows above the sign in/up modals. Somehow it was reverted earlier from another PR.


<img width="494" alt="screen shot 2017-12-08 at 11 44 59 am" src="https://user-images.githubusercontent.com/172531/33792068-8ca02792-dcda-11e7-8757-eb93bfb3fbc8.png">
