### PR TITLE
update hover color

### DIFF
--- a/app/src/renderer/styles/variables.styl
+++ b/app/src/renderer/styles/variables.styl
@@ -29,7 +29,7 @@ bc-dim = app-fg
 
 // anchor
 link = hsl(app-hue, 88%, 70%)
-hover = hsl(app-hue, 96%, 90%)
+hover = hsl(app-hue, 88%, 60%)
 hover-bg = hsl(app-hue, 30%, 19%)
 
 // input


### PR DESCRIPTION
Darkens hover color for a better look (especially when hovering over the icons in the page header, the labels now have a properly dark background).

Fixes #207 

## Before
<img width="136" alt="screen shot 2017-12-09 at 12 15 48 pm" src="https://user-images.githubusercontent.com/172531/33792077-d249f6ba-dcda-11e7-9b59-453f5cdc01a3.png">


## After

<img width="138" alt="screen shot 2017-12-09 at 12 16 04 pm" src="https://user-images.githubusercontent.com/172531/33792076-cb88a146-dcda-11e7-8de9-9eb65e752371.png">
