### PR TITLE
Fix app footer to bottom of screen

### DIFF
--- a/app/src/renderer/components/common/AppFooter.vue
+++ b/app/src/renderer/components/common/AppFooter.vue
@@ -5,11 +5,11 @@ footer.app-footer
       i.material-icons.success done
       span {{ lastHeader.chain_id }} (\#{{ lastHeader.height }})
     .afi
-      i.material-icons settings_ethernet 
+      i.material-icons settings_ethernet
       span {{ nodeIP }}
   .app-footer-container(v-else)
     .afi
-      i.material-icons.fa-spin rotate_right 
+      i.material-icons.fa-spin rotate_right
       span Connecting&hellip;
 </template>
 
@@ -30,8 +30,13 @@ export default {
   border-top px solid bc
   height 3rem + px
   display flex
+  position fixed
   align-items center
   justify-content space-between
+  z-index 1
+  bottom 0
+  width 100%
+  background #15182d
 
   font-label()
   color dim
@@ -46,5 +51,9 @@ export default {
 
     .success
       color success
+
+@media screen and (max-width: 567px)
+  .app-footer-container
+    display none
 
 </style>

--- a/app/src/renderer/components/common/AppFooter.vue
+++ b/app/src/renderer/components/common/AppFooter.vue
@@ -26,20 +26,22 @@ export default {
 <style lang="stylus">
 @require '~variables'
 
+.app-footer
+  position fixed
+  bottom 0
+  right 0
+  width 100vw
+
 .app-footer-container
   border-top px solid bc
   height 3rem + px
   display flex
-  position fixed
   align-items center
   justify-content space-between
-  z-index 1
-  bottom 0
-  width 100%
-  background #15182d
+  background app-bg
 
-  font-label()
   color dim
+  margin-left width-side
 
   .afi
     display flex
@@ -55,5 +57,4 @@ export default {
 @media screen and (max-width: 567px)
   .app-footer-container
     display none
-
 </style>

--- a/app/src/renderer/components/common/AppHeader.vue
+++ b/app/src/renderer/components/common/AppHeader.vue
@@ -58,6 +58,7 @@ export default {
 @require '~variables'
 
 #app-header
+  z-index 100
   .container
     -webkit-app-region: drag
 
@@ -66,7 +67,6 @@ export default {
     position fixed
     top 0
     left 0
-    z-index 100
     width 100%
 
     background app-bg


### PR DESCRIPTION
I fixed the app footer to the bottom of the screen, since on long pages like the balance page it gets hidden and nobody ever sees it. If the screen is very small, the footer hides to show the action buttons instead.

@nylira, let me know what you think.

https://gfycat.com/GreatOrganicLhasaapso