### PR TITLE
use the `gaia-2-dev` testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To run the dev build, you will need the `gaia` binary installed:
 ```golang
 go get github.com/cosmos/gaia
 cd $GOPATH/src/github.com/cosmos/gaia
-git checkout feature/delegation
+git checkout develop
 glide install
 make install
 ```

--- a/app/networks/gaia-2-dev/config.toml
+++ b/app/networks/gaia-2-dev/config.toml
@@ -1,0 +1,24 @@
+# This is a TOML config file.
+# For more information, see https://github.com/toml-lang/toml
+
+proxy_app = "tcp://127.0.0.1:46658"
+moniker = "198.211.127.140"
+fast_sync = true
+
+db_backend = "leveldb"
+log_level = "state:info,*:error"
+#log_level = "*:debug"
+
+
+[rpc]
+laddr = "tcp://0.0.0.0:46657"
+
+
+[consensus]
+create_empty_blocks_interval = 60
+
+
+[p2p]
+max_num_peers = 300
+laddr = "tcp://0.0.0.0:46656"
+seeds = "207.154.200.196:46656,139.59.185.239:46656,174.138.50.234:46656"

--- a/app/networks/gaia-2-dev/genesis.json
+++ b/app/networks/gaia-2-dev/genesis.json
@@ -1,0 +1,343 @@
+{
+  "genesis_time":"2017-12-12T02:31:37Z",
+  "chain_id":"gaia-2-dev",
+  "validators":
+  [
+    
+    {
+      "pub_key": {
+        "data": "2BA51EDE20AFC1EB462F22C10623A24A9C7E1B50282A5FB1E86A2E9B4FF19C47",
+        "type": "ed25519"
+      },
+      "power":1000,
+      "name":"198.211.127.140"
+    }
+    ,
+    {
+      "pub_key": {
+        "data": "C9B26A21B62EF839523D2040C0C4C046D86574CB6DFF92F3C0AF58DF209846FD",
+        "type": "ed25519"
+      },
+      "power":1000,
+      "name":"207.154.200.196"
+    }
+    ,
+    {
+      "pub_key": {
+        "data": "88564A32500A120AA72CEFBCF5462E078E5DDB70B6431F59F778A8DC4DA719A4",
+        "type": "ed25519"
+      },
+      "power":1000,
+      "name":"139.59.185.239"
+    }
+    ,
+    {
+      "pub_key": {
+        "data": "B3D42DEB413DA2BAE6CB1A9162B820783BD2905A90840795D2B11640344908C7",
+        "type": "ed25519"
+      },
+      "power":1000,
+      "name":"174.138.50.234"
+    }
+  ],
+  "app_hash":"",
+  "app_options": {
+    "accounts": [
+      {
+        "name": "relay",
+        "address": "1B1BE55F969F54064628A63B9559E7C21C925165",
+        "pub_key": {
+          "type": "ed25519",
+          "data": "619D3678599971ED29C7529DDD4DA537B97129893598A17C82E3AC9A8BA95279"
+        },
+        "coins": [
+          {
+            "denom": "mycoin",
+            "amount": 9007199254740992
+          }
+        ]
+      },
+      {
+        "name": "greg",
+        "address": "B01C264BFE9CBD45458256E613A6F07061A3A6B6",
+        "pub_key": {
+          "type": "ed25519",
+          "data": "E1FFBD187FA2A922CE1B367532CEAC1AD8E606D576AB0D2E2CAA7EC6B7DAC10F"
+        },
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 1000000
+          },
+          {
+            "denom": "gregcoin",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "monitor1",
+        "address": "CE456B8BA9AFD1CBDF4ED14558E8C30691E549EA",
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 100
+          },
+          {
+            "denom": "moncoin",
+            "amount": 600000
+          },
+          {
+            "denom": "leadertoken",
+            "amount": 1
+          }
+        ]
+      },
+      {
+        "name": "monitor2",
+        "address": "EF708182E21F893634FD8DCB82A5128E16C76B83",
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 100
+          },
+          {
+            "denom": "moncoin",
+            "amount": 0
+          },
+          {
+            "denom": "leadertoken",
+            "amount": 0
+          }
+        ]
+      },
+      {
+        "name": "anton",
+        "address": "40CC622438D3E42148A1FFD3A27C07C100F8FA3D",
+        "pub_key": {
+          "type": "ed25519",
+          "data": "97BD389257763747488803DC686A8819C685936A3CD275D54EABEE51E0117EE6"
+        },
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 100
+          },
+          {
+            "denom": "antoncoin",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "adrian",
+        "address": "4548017683F771FDBCF7D8E74F4723868AA20009",
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 100
+          },
+          {
+            "denom": "adriancoin",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "bucky",
+        "address": "2B24DEE2364762300168DF19B6C18BCE2D399EA2",
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 10000
+          },
+          {
+            "denom": "buckycoin",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "bucky-new",
+        "address": "4FE8FFE12EDBA34BE4E587B2125177AC24594BAF",
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 10000000000
+          },
+          {
+            "denom": "buckycoin",
+            "amount": 2000
+          }
+        ]
+      },
+      {
+        "name": "rigel",
+        "address": "C7A6F5FD77DDCA5C43600F33D14533A27C683F55",
+        "coins": [
+          {
+            "denom": "rigelcoin",
+            "amount": 1000
+          },
+          {
+            "denom": "fermion",
+            "amount": 10000
+          }
+        ]
+      },
+      {
+        "name": "rigel2",
+        "address": "5B228AB64E290F1FC4D3E933B7623CCA3F015C34",
+        "coins": [
+          {
+            "denom": "rigelcoin",
+            "amount": 1000
+          },
+          {
+            "denom": "fermion",
+            "amount": 10000
+          }
+        ]
+      },
+      {
+        "name": "shadow",
+        "address": "B140EFAAE6D5CA1C8E98814C557AF7112E3B9EAE",
+        "pub_key": {
+          "type": "ed25519",
+          "data": "F492282705DF29ACC3BB803D543B7BF98C8080FA28AE85B62B45827EA9DA8167"
+        },
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 100
+          },
+          {
+            "denom": "shadowcoin",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "peng",
+        "address": "7B8422A210D0F0B8734908C093ECF0E9A768BDB8",
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 100
+          },
+          {
+            "denom": "pengcoin",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "matt",
+        "address": "C2104A8191E282AA45D210BA93282B36768EDDA1",
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 100
+          },
+          {
+            "denom": "mattcoin",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "frey",
+        "address": "0F8FB94B5A4D04220F15058B7AA16AF1328B57A9",
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 100
+          },
+          {
+            "denom": "freycoin",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "wancloud",
+        "address": "02C1F2CE501DAF30F758E657B71FC7AD568C4BE5",
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 100
+          },
+          {
+            "denom": "wancloudcoin",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "bianjie",
+        "address": "7D626173FAA69D96E56523A333EAF78F87843CE5",
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 100
+          },
+          {
+            "denom": "bianjiecoin",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "alexis",
+        "address": "42989458D3285F05FE0233EE669A1CCD90AE6F3E",
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 100
+          },
+          {
+            "denom": "alexiscoin",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "zaki",
+        "address": "E2080141FEAD5986FD411121CA077F2835294F5A",
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 100
+          },
+          {
+            "denom": "zakicoin",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "jimyang",
+        "address": "6F94C5B7FEB6EF926A8901A8E8F4B2077D02B354",
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "MichaelYuan",
+        "address": "F75D0FD7036A3BB9092DD0938BBF0A9323224832",
+        "coins": [
+          {
+            "denom": "fermion",
+            "amount": 100000
+          }
+        ]
+      }
+
+    ],
+    "plugin_options": [
+      "coin/issuer", {"app": "sigs", "addr": "B01C264BFE9CBD45458256E613A6F07061A3A6B6"}
+    ]  }
+}

--- a/tasks/testnet.js
+++ b/tasks/testnet.js
@@ -15,7 +15,7 @@ async function get (url) {
 }
 
 async function main () {
-  let network = process.argv[2] || 'gaia-1'
+  let network = process.argv[2] || 'gaia-2-dev'
 
   if (network === 'local') {
     runDev('./app/networks/local')


### PR DESCRIPTION
We should be using the latest testnet so we can try out the delegation features and get the bug fixes and performance updates. I've updated the readme to build from `develop` on gaia, which is now on 0.4.0.

I'm making this PR because I recently had to rebuild my dev environment and I can't get `gaia-1` working with the UI. `gaia-2-dev` seems to work, but I'm getting some errors preventing me from viewing my balance.

<img width="416" alt="screen shot 2017-12-19 at 11 32 35 am" src="https://user-images.githubusercontent.com/172531/34138589-b0267b40-e4b3-11e7-928f-4103864e3b71.png">

Closes #248 
