### PR TITLE
Fabo/fix console error catching

### DIFF
--- a/app/src/renderer/components/staking/LiDelegate.vue
+++ b/app/src/renderer/components/staking/LiDelegate.vue
@@ -5,7 +5,7 @@ transition(name='ts-li-delegate'): .li-delegate(:class='styles'): .li-delegate__
     span
       i.fa.fa-check-square-o(v-if='inCart' @click='rm(delegate)')
       i.fa.fa-square-o(v-else @click='add(delegate)')
-      router-link(v-if="config.devMode" :to="{ name: 'delegate', params: { delegate: delegate.id }}") {{ delegate.id }}
+      router-link(v-if="config.devMode && delegate.id" :to="{ name: 'delegate', params: { delegate: delegate.id }}") {{ delegate.id }}
       a(v-else) {{ delegate.id }}
   .li-delegate__value
     span {{ delegate.country ? delegate.country : 'n/a' }}

--- a/test/unit/helpers/console_error_throw.js
+++ b/test/unit/helpers/console_error_throw.js
@@ -1,5 +1,9 @@
 global.console.error = (...args) => {
-  throw Error('Console Error: ' + args.join(' '))
+  // throwing an error from console.error could be catched by Vue
+  // by throwing it inside an error it will be catched by our unhandledRejection listener
+  return new Promise(() => {
+    throw new Error('Console Error: ' + args.join(' '))
+  })
 }
 
 if (!process.env.LISTENING_TO_UNHANDLED_REJECTION) {

--- a/test/unit/helpers/console_error_throw.js
+++ b/test/unit/helpers/console_error_throw.js
@@ -1,11 +1,3 @@
-global.console.error = (...args) => {
-  // throwing an error from console.error could be catched by Vue
-  // by throwing it inside an error it will be catched by our unhandledRejection listener
-  return new Promise(() => {
-    throw new Error('Console Error: ' + args.join(' '))
-  })
-}
-
 if (!process.env.LISTENING_TO_UNHANDLED_REJECTION) {
   process.on('unhandledRejection', reason => {
     throw reason

--- a/test/unit/specs/LiDelegate.spec.js
+++ b/test/unit/specs/LiDelegate.spec.js
@@ -1,30 +1,18 @@
-import Vuex from 'vuex'
-import { mount, createLocalVue } from 'vue-test-utils'
+import setup from '../helpers/vuex-setup'
 import LiDelegate from 'renderer/components/staking/LiDelegate'
-
-const shoppingCart = require('renderer/vuex/modules/shoppingCart').default({})
-const delegates = require('renderer/vuex/modules/delegates').default({})
-
-const localVue = createLocalVue()
-localVue.use(Vuex)
 
 describe('LiDelegate', () => {
   let wrapper, store, delegate
+  let instance = setup()
 
   beforeEach(() => {
-    store = new Vuex.Store({
-      getters: {
-        shoppingCart: () => shoppingCart.state.delegates,
-        delegates: () => delegates.state,
-        config: () => ({
-          devMode: true
-        })
-      },
-      modules: {
-        shoppingCart,
-        delegates
+    let test = instance.mount(LiDelegate, {
+      propsData: {
+        delegate: {}
       }
     })
+    wrapper = test.wrapper
+    store = test.store
 
     store.commit('addDelegate', {
       pub_key: {
@@ -55,15 +43,9 @@ describe('LiDelegate', () => {
 
     delegate = store.state.delegates[0]
 
-    wrapper = mount(LiDelegate, {
-      localVue,
-      store,
-      propsData: {
-        delegate
-      }
+    wrapper.setData({
+      delegate
     })
-
-    jest.spyOn(store, 'commit')
   })
 
   it('has the expected html structure', () => {

--- a/test/unit/specs/__snapshots__/LiDelegate.spec.js.snap
+++ b/test/unit/specs/__snapshots__/LiDelegate.spec.js.snap
@@ -18,11 +18,12 @@ exports[`LiDelegate has the expected html structure 1`] = `
         <i
           class="fa fa-square-o"
         />
-        <router-link
-          to="[object Object]"
+        <a
+          class=""
+          href="#/staking/delegates/pubkeyX"
         >
           pubkeyX
-        </router-link>
+        </a>
       </span>
     </div>
     <div


### PR DESCRIPTION
Fixes the issue with jest creating an error "couldn't set property '_error' of undefined" and shows correct errors.

I removed the overwrite of console.error again. The thrown error was in some cases catched by Vue and then didn't show the correct error. As far as I saw, console.error is catched by Jest. The important errors where the uncaughtRejections we still catch.