### PR TITLE
remove file menu for Windows builds

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -130,7 +130,11 @@ function createWindow () {
   webContents.on('will-navigate', handleRedirect)
   webContents.on('new-window', handleRedirect)
 
+  // removes menu bar on Windows and Linux but has no effect on macOS
   Menu.setApplicationMenu(null)
+
+  // remove the file menu bar on Windows
+  mainWindow.setMenu(null)
 }
 
 function startProcess (name, args, env) {


### PR DESCRIPTION
Didn't get to test it yet with a real build, but it should work. Ref: https://github.com/electron/electron/blob/master/docs/api/browser-window.md#winsetmenumenu-linux-windows

Closes #236 