### PR TITLE
fix transactions not loaded

### DIFF
--- a/app/src/renderer/vuex/modules/wallet.js
+++ b/app/src/renderer/vuex/modules/wallet.js
@@ -75,7 +75,9 @@ export default ({ commit, node }) => {
       commit('setWalletSequence', res.data)
     },
     async queryWalletHistory ({ state, commit, dispatch }) {
-      let res = await node.coinTxs(state.key.address)
+      // TODO fix in cosmos-sdk-js
+      let res = await fetch('http://localhost:8999/tx/coin/' + state.key.address).then(res => res.json())
+      // let res = await node.coinTxs(state.key.address)
       if (!res) return
       commit('setWalletHistory', res)
 

--- a/app/src/renderer/vuex/modules/wallet.js
+++ b/app/src/renderer/vuex/modules/wallet.js
@@ -1,4 +1,5 @@
 let fs = require('fs-extra')
+let axios = require('axios')
 let { join } = require('path')
 let root = require('../../../root.js')
 
@@ -76,7 +77,7 @@ export default ({ commit, node }) => {
     },
     async queryWalletHistory ({ state, commit, dispatch }) {
       // TODO fix in cosmos-sdk-js
-      let res = await fetch('http://localhost:8999/tx/coin/' + state.key.address).then(res => res.json())
+      let res = await axios.get('http://localhost:8999/tx/coin/' + state.key.address).then(res => res.data)
       // let res = await node.coinTxs(state.key.address)
       if (!res) return
       commit('setWalletHistory', res)


### PR DESCRIPTION
quickfix

the transaction endpoint is /tx/coin but cosmos-sdk-js requests from the endpoint /tx/coins

@mappum this raises too many errors. could you maybe fix it in the sdk directly?