### PR TITLE
LiDelegate loop fix

### DIFF
--- a/app/src/renderer/components/staking/LiDelegate.vue
+++ b/app/src/renderer/components/staking/LiDelegate.vue
@@ -46,6 +46,7 @@ export default {
     },
     vpTotal () {
       return this.delegates
+        .slice()
         .sort((a, b) => b.voting_power - a.voting_power)
         .slice(0, 100)
         .reduce((sum, v) => sum + v.voting_power, 0)

--- a/test/unit/specs/LiDelegate.spec.js
+++ b/test/unit/specs/LiDelegate.spec.js
@@ -54,15 +54,15 @@ describe('LiDelegate', () => {
   })
 
   it('should show the voting power', () => {
-    expect(wrapper.html()).toContain('75%')
+    expect(wrapper.html()).toContain('25%')
   })
 
   it('should show the number of bonded atoms', () => {
-    expect(wrapper.html()).toContain('30,000')
+    expect(wrapper.html()).toContain('10,000')
   })
 
   it('should show the relative voting power as a bar', () => {
-    expect(wrapper.vm.$el.querySelector('.voting_power .bar').style.width).toBe('100%')
+    expect(wrapper.vm.$el.querySelector('.voting_power .bar').style.width).toBe('33%')
   })
 
   it('should add to cart', () => {


### PR DESCRIPTION
Closes #319 

Was previously triggering updates in a loop since it would sort the `this.delegates` array, which would mutate the array and trigger another update. Fixed by cloning.
  