### PR TITLE
implemented blocks page

### DIFF
--- a/app/src/renderer/components/common/AppMenu.vue
+++ b/app/src/renderer/components/common/AppMenu.vue
@@ -6,7 +6,7 @@ menu.app-menu
     list-item(to="/staking" exact @click.native="close" title="Delegates")
     list-item(to="/validators" exact @click.native="close" title="Validators" v-bind:class="{ 'active': isValidatorPage }")
     list-item(to="/proposals" exact @click.native="close" title="Proposals" v-if="config.devMode")
-    list-item(to="/blockchain" exact @click.native="close" title="Monitor" v-if="config.devMode")
+    list-item(to="/blockchain" exact @click.native="close" title="Blocks" v-if="config.devMode")
     connectivity
   user-pane
 </template>

--- a/app/src/renderer/components/common/AppMenu.vue
+++ b/app/src/renderer/components/common/AppMenu.vue
@@ -6,7 +6,7 @@ menu.app-menu
     list-item(to="/staking" exact @click.native="close" title="Delegates")
     list-item(to="/validators" exact @click.native="close" title="Validators" v-bind:class="{ 'active': isValidatorPage }")
     list-item(to="/proposals" exact @click.native="close" title="Proposals" v-if="config.devMode")
-    list-item(to="/blockchain" exact @click.native="close" title="Blocks" v-if="config.devMode")
+    list-item(to="/blockchain" exact @click.native="close" title="Blocks")
     connectivity
   user-pane
 </template>

--- a/app/src/renderer/components/common/NiConnectivity.vue
+++ b/app/src/renderer/components/common/NiConnectivity.vue
@@ -16,9 +16,8 @@ export default {
     ListItem
   },
   computed: {
-    ...mapGetters(['lastHeader', 'nodeIP', 'connected']),
+    ...mapGetters(['lastHeader', 'nodeIP', 'connected', 'validators']),
     blockString () {
-      //- TODO: calculate actual number of active nodes, not just validators
       return `${this.lastHeader.chain_id} (#${num.prettyInt(this.lastHeader.height)})`
     }
   },

--- a/app/src/renderer/components/common/NiConnectivity.vue
+++ b/app/src/renderer/components/common/NiConnectivity.vue
@@ -16,10 +16,10 @@ export default {
     ListItem
   },
   computed: {
-    ...mapGetters(['lastHeader', 'nodeIP', 'connected', 'validators']),
+    ...mapGetters(['lastHeader', 'nodeIP', 'connected']),
     blockString () {
       //- TODO: calculate actual number of active nodes, not just validators
-      return `${this.lastHeader.chain_id} (#${num.prettyInt(this.lastHeader.height)}) (${this.validators.length} Nodes)`
+      return `${this.lastHeader.chain_id} (#${num.prettyInt(this.lastHeader.height)})`
     }
   },
   data: () => ({

--- a/app/src/renderer/components/common/NiConnectivity.vue
+++ b/app/src/renderer/components/common/NiConnectivity.vue
@@ -16,9 +16,10 @@ export default {
     ListItem
   },
   computed: {
-    ...mapGetters(['lastHeader', 'nodeIP', 'connected']),
+    ...mapGetters(['lastHeader', 'nodeIP', 'connected', 'validators']),
     blockString () {
-      return `${this.lastHeader.chain_id} (#${num.prettyInt(this.lastHeader.height)})`
+      //- TODO: calculate actual number of active nodes, not just validators
+      return `${this.lastHeader.chain_id} (#${num.prettyInt(this.lastHeader.height)}) (${this.validators.length} Nodes)`
     }
   },
   data: () => ({

--- a/app/src/renderer/components/common/NiDataEmpty.vue
+++ b/app/src/renderer/components/common/NiDataEmpty.vue
@@ -1,13 +1,17 @@
 <template lang="pug">
 data-msg(icon="info_outline")
-  div(slot="title") N/A
-  div(slot="subtitle") No data available yet.
+  h4(v-if="title" slot="title") {{ title }}
+  h4(v-else slot="title") N/A
+
+  h5(v-if="subtitle" slot="subtitle") {{ subtitle }}
+  h5(v-else slot="subtitle") No data available yet.
 </template>
 
 <script>
 import DataMsg from 'common/NiDataMsg'
 export default {
   name: 'ni-data-empty',
+  props: ['title', 'subtitle'],
   components: {
     DataMsg
   }

--- a/app/src/renderer/components/common/NiListItem.vue
+++ b/app/src/renderer/components/common/NiListItem.vue
@@ -99,6 +99,10 @@ export default {
       background transparent
       z-index z(listItem)
 
+    .ni-li-dt
+    .ni-li-dd
+      color link
+
   &.router-link-exact-active
     .ni-li-title
       color bright

--- a/app/src/renderer/components/monitor/PageBlock.vue
+++ b/app/src/renderer/components/monitor/PageBlock.vue
@@ -39,7 +39,7 @@ page(:title="pageBlockTitle")
 
   part(title='Transactions')
     list-item(v-if="block.header.num_txs > 0" v-for="tx in block.data.txs" :key="tx.id" dt="Transaction" :dd="TODO")
-    data-empty(v-if="block.header.num_txs === 0" title="Empty Block" subtitle="No transaction data in this block.")
+    data-empty(v-if="block.header.num_txs === 0" title="Empty Block" subtitle="There were no transactions in this block.")
 </template>
 
 <script>

--- a/app/src/renderer/components/monitor/PageBlock.vue
+++ b/app/src/renderer/components/monitor/PageBlock.vue
@@ -16,7 +16,7 @@ page(:title="`Block ${block.header.height}`")
 
   part(title='Header')
     list-item(dt="Chain ID" :dd="block.header.chain_id")
-    list-item(dt="Time" :dd="block.header.time")
+    list-item(dt="Time" :dd="blockHeaderTime")
     list-item(dt="Transactions" :dd="block.header.num_txs")
     list-item(dt="Last Commit Hash" :dd="block.header.last_commit_hash")
     list-item(dt="Validators Hash" :dd="block.header.validators_hash")
@@ -38,13 +38,15 @@ page(:title="`Block ${block.header.height}`")
     :dd="p.signature.data")
 
   part(title='Transactions')
-    list-item(v-for="tx in block.data.txs" :key="tx.id"
-      dt="Transaction" :dd="TODO")
+    list-item(v-if="block.header.num_txs > 0" v-for="tx in block.data.txs" :key="tx.id" dt="Transaction" :dd="TODO")
+    data-empty(v-if="block.header.num_txs === 0")
 </template>
 
 <script>
 import { mapGetters } from 'vuex'
+import moment from 'moment'
 import axios from 'axios'
+import DataEmpty from 'common/NiDataEmpty'
 import ToolBar from 'common/NiToolBar'
 import ListItem from 'common/NiListItem'
 import Part from 'common/NiPart'
@@ -52,15 +54,20 @@ import Page from 'common/NiPage'
 export default {
   name: 'page-block',
   components: {
+    DataEmpty,
     ToolBar,
     ListItem,
     Part,
     Page
   },
   computed: {
-    ...mapGetters(['blockchain'])
+    ...mapGetters(['blockchain']),
+    blockHeaderTime () {
+      return moment(this.block.header.time).format('MMMM Do YYYY — hh:mm:ss')
+    }
   },
   data: () => ({
+    moment: moment,
     blockUrl: '',
     block_meta: {
       block_id: {

--- a/app/src/renderer/components/monitor/PageBlock.vue
+++ b/app/src/renderer/components/monitor/PageBlock.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-page(:title="`Block ${block.header.height}`")
+page(:title="pageBlockTitle")
   div(slot="menu"): tool-bar
     router-link(to="/blockchain")
       i.material-icons arrow_back
@@ -45,6 +45,7 @@ page(:title="`Block ${block.header.height}`")
 <script>
 import { mapGetters } from 'vuex'
 import moment from 'moment'
+import num from 'scripts/num'
 import axios from 'axios'
 import DataEmpty from 'common/NiDataEmpty'
 import ToolBar from 'common/NiToolBar'
@@ -64,9 +65,13 @@ export default {
     ...mapGetters(['blockchain']),
     blockHeaderTime () {
       return moment(this.block.header.time).format('MMMM Do YYYY — hh:mm:ss')
+    },
+    pageBlockTitle () {
+      return 'Block #' + num.prettyInt(this.block.header.height)
     }
   },
   data: () => ({
+    num: num,
     moment: moment,
     blockUrl: '',
     block_meta: {

--- a/app/src/renderer/components/monitor/PageBlock.vue
+++ b/app/src/renderer/components/monitor/PageBlock.vue
@@ -39,7 +39,7 @@ page(:title="`Block ${block.header.height}`")
 
   part(title='Transactions')
     list-item(v-if="block.header.num_txs > 0" v-for="tx in block.data.txs" :key="tx.id" dt="Transaction" :dd="TODO")
-    data-empty(v-if="block.header.num_txs === 0")
+    data-empty(v-if="block.header.num_txs === 0" title="Empty Block" subtitle="No transaction data in this block.")
 </template>
 
 <script>

--- a/app/src/renderer/components/monitor/PageBlockchain.vue
+++ b/app/src/renderer/components/monitor/PageBlockchain.vue
@@ -1,24 +1,17 @@
 <template lang="pug">
-page(title='Blockchain')
+page(title='Monitor')
   div(slot="menu"): tool-bar
-    a(@click='setSearch(true)')
-      i.material-icons search
-      .label Search
-
   template(v-if="blockchain")
-    part(title='Metadata')
-      list-item(dt='Network Name' :dd='status.node_info.network')
-      list-item(dt='App Version' :dd='version')
-      list-item(dt='Tendermint Version' :dd='status.node_info.version')
+    part(title='Versions')
+      list-item(dt='Network Name' :dd='lastHeader.chain_id')
+      list-item(dt='ABCI Version' :dd='abciVersion')
+      list-item(dt='Tendermint Version' :dd='tendermintVersion')
 
-    part(title='Block')
+    part(title='Latest Block')
       list-item(dt='Block Height' :dd='num.prettyInt(status.latest_block_height)'
         :to="{ name: 'block', params: { block: status.latest_block_height} }")
       list-item(dt='Latest Block Time' :dd='latestBlockTime')
       list-item(dt='Latest Block Hash' :dd='status.latest_block_hash')
-
-    part(title='Nodes')
-      list-item(dt='Active Nodes' :dd='validators.length')
 
   data-error(v-else)
 </template>
@@ -42,14 +35,15 @@ export default {
     ToolBar
   },
   computed: {
-    ...mapGetters(['blockchain', 'config', 'validators']),
+    ...mapGetters(['blockchain', 'validators', 'lastHeader']),
     status () {
-      console.log(this.config)
-      console.log(this.validators)
       return this.blockchain.status
     },
-    version () {
-      return this.blockchain.abciInfo.response.data.substring(10, this.blockchain.abciInfo.response.length)
+    abciVersion () {
+      return this.blockchain.abciInfo.response.data.substring(6, this.blockchain.abciInfo.response.length)
+    },
+    tendermintVersion () {
+      return this.status.node_info.version.substring(0, 6)
     },
     currentRate () {
       let txs = 0
@@ -76,11 +70,6 @@ export default {
   data: () => ({
     moment: moment,
     num: num
-  }),
-  methods: {
-    setSearch (bool) {
-      this.$store.commit('setSearchVisible', ['balances', bool])
-    },
-  }
+  })
 }
 </script>

--- a/app/src/renderer/components/monitor/PageBlockchain.vue
+++ b/app/src/renderer/components/monitor/PageBlockchain.vue
@@ -1,26 +1,24 @@
 <template lang="pug">
 page(title='Blockchain')
   div(slot="menu"): tool-bar
-    router-link(to="/search" exact)
+    a(@click='setSearch(true)')
       i.material-icons search
       .label Search
 
-  template(v-if="bc")
+  template(v-if="blockchain")
     part(title='Metadata')
-      list-item(dt='Network' :dd='bc.status.node_info.network')
+      list-item(dt='Network Name' :dd='status.node_info.network')
       list-item(dt='App Version' :dd='version')
-      list-item(dt='Tendermint Version' :dd='bc.status.node_info.version')
+      list-item(dt='Tendermint Version' :dd='status.node_info.version')
 
     part(title='Block')
-      list-item(dt='Block Height' :dd='num.prettyInt(bc.status.latest_block_height)'
-        :to="{ name: 'block', params: { block: bc.status.latest_block_height} }")
-      list-item(dt='Latest Block Time' :dd='readableDate(bc.status.latest_block_time)')
-      list-item(dt='Latest Block Hash' :dd='bc.status.latest_block_hash')
+      list-item(dt='Block Height' :dd='num.prettyInt(status.latest_block_height)'
+        :to="{ name: 'block', params: { block: status.latest_block_height} }")
+      list-item(dt='Latest Block Time' :dd='latestBlockTime')
+      list-item(dt='Latest Block Hash' :dd='status.latest_block_hash')
 
     part(title='Nodes')
       list-item(dt='Active Nodes' :dd='validators.length')
-      list-item(dt='Current Rate' :dd="currentRate + ' bytes/s'")
-      list-item(dt='Average Rate' :dd="averageRate + ' bytes/s'")
 
   data-error(v-else)
 </template>
@@ -45,21 +43,19 @@ export default {
   },
   computed: {
     ...mapGetters(['blockchain', 'config', 'validators']),
-    bc () {
-      console.log(this.blockchain)
-      return this.blockchain
+    status () {
+      console.log(this.config)
+      console.log(this.validators)
+      return this.blockchain.status
     },
     version () {
-      return this.bc.abciInfo.data.substring(10, this.bc.abciInfo.data.length)
-    },
-    avgTxThroughput () {
-      return 100
-      // return Math.round(this.bc.network.avg_tx_throughput * 1000) / 1000
+      return this.blockchain.abciInfo.response.data.substring(10, this.blockchain.abciInfo.response.length)
     },
     currentRate () {
       let txs = 0
       // this.validators.reduce(txs, v => (txs += v.connection_status.SendMonitor.CurRate))
       for (let i = 0; i < this.validators.length; i++) {
+        console.log(this.validators[i])
         txs += this.validators[i].connection_status.SendMonitor.CurRate
       }
       let average = Math.round(txs / this.validators.length)
@@ -72,6 +68,9 @@ export default {
       }
       let average = Math.round(txs / this.validators.length)
       return average
+    },
+    latestBlockTime () {
+      return moment(this.status.latest_block_time).format('MMMM Do YYYY — hh:mm:ss')
     }
   },
   data: () => ({
@@ -79,8 +78,8 @@ export default {
     num: num
   }),
   methods: {
-    readableDate (ms) {
-      return moment(ms / 1000000).format('HH:mm:ss.SSS')
+    setSearch (bool) {
+      this.$store.commit('setSearchVisible', ['balances', bool])
     },
   }
 }

--- a/app/src/renderer/components/monitor/PageBlockchain.vue
+++ b/app/src/renderer/components/monitor/PageBlockchain.vue
@@ -4,12 +4,6 @@ page(title='Blockchain')
     router-link(to="/search" exact)
       i.material-icons search
       .label Search
-    a(@click='toggleBlockchainSelect')
-      i.material-icons(v-if='!config.modals.blockchain.active') filter_list
-      i.material-icons(v-else='') close
-      .label Switch Blockchain
-
-  blockchain-select-modal
 
   template(v-if="bc")
     part(title='Metadata')
@@ -35,7 +29,6 @@ page(title='Blockchain')
 import moment from 'moment'
 import num from 'scripts/num'
 import { mapGetters } from 'vuex'
-import BlockchainSelectModal from 'monitor/BlockchainSelectModal'
 import ListItem from 'common/NiListItem'
 import DataError from 'common/NiDataError'
 import Page from 'common/NiPage'
@@ -44,7 +37,6 @@ import ToolBar from 'common/NiToolBar'
 export default {
   name: 'page-blockchain',
   components: {
-    BlockchainSelectModal,
     ListItem,
     DataError,
     Page,
@@ -53,18 +45,16 @@ export default {
   },
   computed: {
     ...mapGetters(['blockchain', 'config', 'validators']),
-    bc () { return this.blockchain },
+    bc () {
+      console.log(this.blockchain)
+      return this.blockchain
+    },
     version () {
-      let v
-      if (this.bc.blockchainName === 'venus') {
-        v = this.bc.abciInfo.data
-      } else {
-        v = this.bc.abciInfo.data.substring(10, this.bc.abciInfo.data.length)
-      }
-      return v
+      return this.bc.abciInfo.data.substring(10, this.bc.abciInfo.data.length)
     },
     avgTxThroughput () {
-      return Math.round(this.bc.network.avg_tx_throughput * 1000) / 1000
+      return 100
+      // return Math.round(this.bc.network.avg_tx_throughput * 1000) / 1000
     },
     currentRate () {
       let txs = 0
@@ -92,9 +82,6 @@ export default {
     readableDate (ms) {
       return moment(ms / 1000000).format('HH:mm:ss.SSS')
     },
-    toggleBlockchainSelect () {
-      this.$store.commit('setModalBlockchain', !this.config.modals.blockchain.active)
-    }
   }
 }
 </script>

--- a/app/src/renderer/components/monitor/PageBlockchain.vue
+++ b/app/src/renderer/components/monitor/PageBlockchain.vue
@@ -1,19 +1,12 @@
 <template lang="pug">
 page(title='Monitor')
   div(slot="menu"): tool-bar
-  template(v-if="blockchain")
-    part(title='Versions')
-      list-item(dt='Network Name' :dd='lastHeader.chain_id')
-      list-item(dt='ABCI Version' :dd='abciVersion')
-      list-item(dt='Tendermint Version' :dd='tendermintVersion')
-
+  template
     part(title='Latest Block')
-      list-item(dt='Block Height' :dd='num.prettyInt(status.latest_block_height)'
-        :to="{ name: 'block', params: { block: status.latest_block_height} }")
+      list-item(dt='Block Height' :dd='num.prettyInt(lastHeader.height)'
+        :to="{ name: 'block', params: { block: lastHeader.height} }")
       list-item(dt='Latest Block Time' :dd='latestBlockTime')
       list-item(dt='Latest Block Hash' :dd='status.latest_block_hash')
-
-  data-error(v-else)
 </template>
 
 <script>
@@ -38,30 +31,6 @@ export default {
     ...mapGetters(['blockchain', 'validators', 'lastHeader']),
     status () {
       return this.blockchain.status
-    },
-    abciVersion () {
-      return this.blockchain.abciInfo.response.data.substring(6, this.blockchain.abciInfo.response.length)
-    },
-    tendermintVersion () {
-      return this.status.node_info.version.substring(0, 6)
-    },
-    currentRate () {
-      let txs = 0
-      // this.validators.reduce(txs, v => (txs += v.connection_status.SendMonitor.CurRate))
-      for (let i = 0; i < this.validators.length; i++) {
-        console.log(this.validators[i])
-        txs += this.validators[i].connection_status.SendMonitor.CurRate
-      }
-      let average = Math.round(txs / this.validators.length)
-      return average
-    },
-    averageRate () {
-      let txs = 0
-      for (let i = 0; i < this.validators.length; i++) {
-        txs += this.validators[i].connection_status.SendMonitor.AvgRate
-      }
-      let average = Math.round(txs / this.validators.length)
-      return average
     },
     latestBlockTime () {
       return moment(this.status.latest_block_time).format('MMMM Do YYYY — hh:mm:ss')

--- a/app/src/renderer/components/monitor/PageBlockchain.vue
+++ b/app/src/renderer/components/monitor/PageBlockchain.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-page(title='Monitor')
+page(title='Blocks')
   div(slot="menu"): tool-bar
   template
     part(title='Latest Block')

--- a/app/src/renderer/components/staking/PageBond.vue
+++ b/app/src/renderer/components/staking/PageBond.vue
@@ -19,7 +19,7 @@ page.page-bond(title="Bond Atoms")
       | #[a.reserved-atoms__restart(@click="resetAlloc") &nbsp;(start over?)]
 
   form-struct(:submit="onSubmit")
-    form-group(v-for='(delegate, index) in fields.delegates' key='delegate.id'
+    form-group(v-for='(delegate, index) in fields.delegates' :key='delegate.id'
       :error="$v.fields.delegates.$each[index].$error")
       Label {{ shortenLabel(delegate.delegate.description.moniker, 10) }} - {{ shortenLabel(delegate.delegate.id, 20) }} ({{ percentAtoms(delegate.atoms) }})
       field-group
@@ -183,7 +183,7 @@ export default {
   watch: {
     shoppingCart (newVal) {
       this.leaveIfEmpty(newVal.length)
-      // this.resetAlloc()
+      this.resetAlloc()
       if (this.equalize) { this.equalAlloc }
     }
   },

--- a/app/src/renderer/components/staking/PageDelegate.vue
+++ b/app/src/renderer/components/staking/PageDelegate.vue
@@ -57,7 +57,7 @@ export default {
         description: {}
       }
       if (this.delegates && this.$route.params.delegate) {
-        value = this.delegates.find(v => v.id === this.$route.params.delegate)
+        value = this.delegates.find(v => v.id === this.$route.params.delegate) || value
       }
       return value
     },

--- a/app/src/renderer/node.js
+++ b/app/src/renderer/node.js
@@ -12,6 +12,7 @@ module.exports = function (nodeIP) {
   let node = new RestClient(RELAY_SERVER)
 
   Object.assign(node, {
+    nodeIP,
     lcdConnected: () => node.listKeys()
       .then(() => true, () => false),
 

--- a/app/src/renderer/vuex/modules/blockchain.js
+++ b/app/src/renderer/vuex/modules/blockchain.js
@@ -31,18 +31,18 @@ export default ({ commit, node }) => {
     }
   }
 
-  function getBlocks () {
-    node.rpc.subscribe({ event: 'NewBlockHeader' }, (err, event) => {
-      if (err) return console.error('error subscribing to new block headers', err)
-      console.log(event)
-    })
-  }
-  getBlocks()
+  // function getBlocks () {
+  //   node.rpc.subscribe({ event: 'NewBlockHeader' }, (err, event) => {
+  //     if (err) return console.error('error subscribing to new block headers', err)
+  //     console.log(event)
+  //   })
+  // }
+  // getBlocks()
 
-  // setTimeout(() => {
-  //   mutations.getStatus(state)
-  //   mutations.getAbciInfo(state)
-  // }, 3000)
+  setTimeout(() => {
+    mutations.getStatus(state)
+    mutations.getAbciInfo(state)
+  }, 3000)
 
   return { state, mutations }
 }

--- a/app/src/renderer/vuex/modules/blockchain.js
+++ b/app/src/renderer/vuex/modules/blockchain.js
@@ -1,0 +1,45 @@
+import axios from 'axios'
+
+export default ({ commit }) => {
+  const state = {
+    urlPrefix: 'https://',
+    blockchainName: 'gaia-2-dev',
+    urlSuffix: '-node0.testnets.interblock.io',
+    status: {},
+    abciInfo: {},
+    topAvgTxRate: 0
+  }
+
+  const mutations = {
+    setBlockchainName (state, name) {
+      state.blockchainName = name
+    },
+    setTopAvgTxRate (state, value) {
+      state.topAvgTxRate = value
+    },
+    getStatus (state) {
+      let url = state.urlPrefix + state.blockchainName + state.urlSuffix
+      console.log(url + '/status')
+      axios(url + '/status').then((err, res) => {
+        if (err) {
+          return console.error('err', err)
+        }
+        console.log('status', JSON.stringify(res.body.result, null, 2))
+        state.status = res.body.result
+      })
+    },
+    getAbciInfo (state) {
+      let url = state.urlPrefix + state.blockchainName + state.urlSuffix
+      console.log(url + '/abci_info')
+      axios(url + '/abci_info').then((err, res) => {
+        if (err) {
+          return console.error('err', err)
+        }
+        console.log('abci_info', JSON.stringify(res.body.result, null, 2))
+        state.abciInfo = res.body.result.response
+      })
+    }
+  }
+
+  return { state, mutations }
+}

--- a/app/src/renderer/vuex/modules/blockchain.js
+++ b/app/src/renderer/vuex/modules/blockchain.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-export default ({ commit }) => {
+export default ({ commit, node }) => {
   const state = {
     urlPrefix: 'https://',
     blockchainName: 'gaia-2-dev',
@@ -31,10 +31,18 @@ export default ({ commit }) => {
     }
   }
 
-  setTimeout(() => {
-    mutations.getStatus(state)
-    mutations.getAbciInfo(state)
-  }, 3000)
+  function getBlocks () {
+    node.rpc.subscribe({ event: 'NewBlockHeader' }, (err, event) => {
+      if (err) return console.error('error subscribing to new block headers', err)
+      console.log(event)
+    })
+  }
+  getBlocks()
+
+  // setTimeout(() => {
+  //   mutations.getStatus(state)
+  //   mutations.getAbciInfo(state)
+  // }, 3000)
 
   return { state, mutations }
 }

--- a/app/src/renderer/vuex/modules/blockchain.js
+++ b/app/src/renderer/vuex/modules/blockchain.js
@@ -19,27 +19,22 @@ export default ({ commit }) => {
     },
     getStatus (state) {
       let url = state.urlPrefix + state.blockchainName + state.urlSuffix
-      console.log(url + '/status')
-      axios(url + '/status').then((err, res) => {
-        if (err) {
-          return console.error('err', err)
-        }
-        console.log('status', JSON.stringify(res.body.result, null, 2))
-        state.status = res.body.result
+      axios(url + '/status').then((res) => {
+        state.status = res.data.result
       })
     },
     getAbciInfo (state) {
       let url = state.urlPrefix + state.blockchainName + state.urlSuffix
-      console.log(url + '/abci_info')
-      axios(url + '/abci_info').then((err, res) => {
-        if (err) {
-          return console.error('err', err)
-        }
-        console.log('abci_info', JSON.stringify(res.body.result, null, 2))
-        state.abciInfo = res.body.result.response
+      axios(url + '/abci_info').then((res) => {
+        state.abciInfo = res.data.result
       })
     }
   }
+
+  setTimeout(() => {
+    mutations.getStatus(state)
+    mutations.getAbciInfo(state)
+  }, 3000)
 
   return { state, mutations }
 }

--- a/app/src/renderer/vuex/modules/delegation.js
+++ b/app/src/renderer/vuex/modules/delegation.js
@@ -2,6 +2,8 @@ import axios from 'axios'
 
 export default ({ commit }) => {
   let state = {
+    delegationActive: false,
+
     // our delegations, maybe not yet committed
     delegates: [],
 
@@ -10,6 +12,9 @@ export default ({ commit }) => {
   }
 
   const mutations = {
+    activateDelegation (state) {
+      state.delegationActive = true
+    },
     addToCart (state, delegate) {
       // don't add to cart if already in cart
       for (let existingDelegate of state.delegates) {

--- a/app/src/renderer/vuex/modules/delegation.js
+++ b/app/src/renderer/vuex/modules/delegation.js
@@ -25,9 +25,6 @@ export default ({ commit }) => {
     removeFromCart (state, delegate) {
       state.delegates = state.delegates.filter(c => c.id !== delegate)
     },
-    reserveAtoms (state, {delegateId, value}) {
-      state.delegates.find(d => d.id === delegateId).reservedAtoms = value
-    },
     setShares (state, {candidateId, value}) {
       state.delegates.find(c => c.id === candidateId).atoms = value
     },
@@ -45,7 +42,6 @@ export default ({ commit }) => {
   let actions = {
     // load committed delegations from LCD
     async getBondedDelegates ({ state, dispatch }, {candidates, address}) {
-      // TODO move into cosmos-sdk
       candidates.forEach(candidate => {
         dispatch('getBondedDelegate', {address, pubkey: candidate.pub_key.data})
       })
@@ -94,8 +90,6 @@ export default ({ commit }) => {
           })
         })
       }
-
-      commit('activateDelegation', true)
     }
   }
 

--- a/app/src/renderer/vuex/modules/index.js
+++ b/app/src/renderer/vuex/modules/index.js
@@ -1,11 +1,12 @@
 export default (opts) => ({
-  delegates: require('./delegates.js').default(opts),
+  blockchain: require('./blockchain.js').default(opts),
   config: require('./config.js').default(opts),
+  delegates: require('./delegates.js').default(opts),
+  delegation: require('./delegation.js').default(opts),
   filters: require('./filters.js').default(opts),
   node: require('./node.js').default(opts),
   notifications: require('./notifications.js').default(opts),
   proposals: require('./proposals.js').default(opts),
-  delegation: require('./delegation.js').default(opts),
   user: require('./user.js').default(opts),
   validators: require('./validators.js').default(opts),
   wallet: require('./wallet.js').default(opts)

--- a/app/src/renderer/vuex/modules/node.js
+++ b/app/src/renderer/vuex/modules/node.js
@@ -57,9 +57,11 @@ export default function ({ node }) {
         })
       })
       node.rpc.subscribe({ event: 'NewBlockHeader' }, (err, event) => {
-        if (err) return console.error('error subscribing to headers', err)
-        commit('setConnected', true)
-        dispatch('setLastHeader', event.data.data.header)
+        console.log(err)
+        // if (err) return console.error('error subscribing to headers', err)
+        // commit('setConnected', true)
+        console.log(event)
+        // dispatch('setLastHeader', event.data.data.header)
       })
 
       dispatch('pollRPCConnection')

--- a/app/src/renderer/vuex/modules/proposals.js
+++ b/app/src/renderer/vuex/modules/proposals.js
@@ -3,24 +3,6 @@ import data from '../json/proposals.json'
 export default ({ commit }) => {
   const state = data
   const mutations = {
-    ADD_PROPOSAL (state, proposal) {
-      proposal.created_at = Date.now()
-      state.push(proposal)
-      console.log('creating', JSON.stringify(proposal))
-    },
-    RM_PROPOSAL (state, proposal) {
-      state.splice(state.indexOf(proposal), 1)
-      console.log('removing', JSON.stringify(proposal))
-    }
-    /*
-    UPDATE_PROPOSAL (state, proposal) {
-      console.log('modifying', JSON.stringify(proposal))
-      Proposals.child(proposal.id).update({
-        body: proposal.body,
-        updated_at: new Date.now()
-      })
-    }
-    */
   }
   return { state, mutations }
 }

--- a/test/unit/helpers/node_mock.js
+++ b/test/unit/helpers/node_mock.js
@@ -2,8 +2,16 @@ module.exports = {
   // REST
   lcdConnected: () => Promise.resolve(true),
   getKey: () => ({}),
-  generateKey: () => ({key: '123'}),
+  generateKey: () => ({
+    key: '123',
+    seed_phrase: 'a b c d e f g h i j k l'
+  }),
+  updateKey: () => {},
   listKeys: () => [],
+  recoverKey: () => ({
+    key: '123',
+    seed_phrase: 'a b c d e f g h i j k l'
+  }),
   queryAccount: () => null,
   queryNonce: () => '123',
   buildSend: (args) => {

--- a/test/unit/helpers/vuex-setup.js
+++ b/test/unit/helpers/vuex-setup.js
@@ -8,16 +8,15 @@ const Modules = require('renderer/vuex/modules').default
 const Getters = require('renderer/vuex/getters')
 
 export default function vuexSetup () {
-  const node = require('../helpers/node_mock')
-  const modules = Modules({
-    node
-  })
-
   const localVue = createLocalVue()
   localVue.use(Vuex)
   localVue.use(VueRouter)
 
   function init (componentConstructor, testType = shallow, {stubs, getters = {}, propsData}) {
+    const node = require('../helpers/node_mock')
+    const modules = Modules({
+      node
+    })
     let store = new Vuex.Store({
       getters: Object.assign({}, Getters, getters),
       modules

--- a/test/unit/specs/NISessionSignIn.spec.js
+++ b/test/unit/specs/NISessionSignIn.spec.js
@@ -1,33 +1,18 @@
-import Vuex from 'vuex'
+import setup from '../helpers/vuex-setup'
 import Vuelidate from 'vuelidate'
-import { mount, createLocalVue } from 'vue-test-utils'
 import htmlBeautify from 'html-beautify'
 import NiSessionSignIn from 'common/NiSessionSignIn'
 
-const user = require('renderer/vuex/modules/user').default({})
-
-const localVue = createLocalVue()
-localVue.use(Vuex)
-localVue.use(Vuelidate)
+let instance = setup()
+instance.localVue.use(Vuelidate)
 
 describe('NiSessionSignIn', () => {
   let wrapper, store
 
   beforeEach(() => {
-    store = new Vuex.Store({
-      modules: {
-        user
-      },
-      getters: {
-        user: () => user.state
-      }
-    })
-    wrapper = mount(NiSessionSignIn, {
-      localVue,
-      store
-    })
-    store.commit = jest.fn()
-    store.dispatch = jest.fn(async () => null)
+    let test = instance.mount(NiSessionSignIn)
+    store = test.store
+    wrapper = test.wrapper
   })
 
   it('has the expected html structure', () => {

--- a/test/unit/specs/NISessionSignUp.spec.js
+++ b/test/unit/specs/NISessionSignUp.spec.js
@@ -1,37 +1,18 @@
-import Vuex from 'vuex'
+import setup from '../helpers/vuex-setup'
 import Vuelidate from 'vuelidate'
-import { mount, createLocalVue } from 'vue-test-utils'
 import htmlBeautify from 'html-beautify'
 import NISessionSignUp from 'common/NiSessionSignUp'
 
-const user = require('renderer/vuex/modules/user').default({})
-const notifications = require('renderer/vuex/modules/notifications').default({})
-
-const localVue = createLocalVue()
-localVue.use(Vuex)
-localVue.use(Vuelidate)
+let instance = setup()
+instance.localVue.use(Vuelidate)
 
 describe('NISessionSignUp', () => {
   let wrapper, store
 
   beforeEach(() => {
-    store = new Vuex.Store({
-      modules: {
-        user,
-        notifications
-      },
-      actions: {
-        async createKey () {
-          return {}
-        }
-      }
-    })
-    wrapper = mount(NISessionSignUp, {
-      localVue,
-      store
-    })
-    store.commit = jest.fn()
-    store.dispatch = jest.fn(() => Promise.resolve({}))
+    let test = instance.mount(NISessionSignUp)
+    store = test.store
+    wrapper = test.wrapper
   })
 
   it('has the expected html structure', () => {
@@ -58,7 +39,7 @@ describe('NISessionSignUp', () => {
       signUpBackup: true
     }})
     await wrapper.vm.onSubmit()
-    expect(store.commit.mock.calls[0]).toEqual(['setModalSession', false])
+    expect(store.commit).toHaveBeenCalledWith('setModalSession', false)
   })
 
   it('should signal signedin state on successful login', async () => {

--- a/test/unit/specs/NiDataEmpty.spec.js
+++ b/test/unit/specs/NiDataEmpty.spec.js
@@ -18,12 +18,12 @@ describe('NiDataEmpty', () => {
   })
 
   it('has a title', () => {
-    expect(wrapper.find('.ni-data-msg__title div').text().trim())
+    expect(wrapper.find('.ni-data-msg__title h4').text().trim())
       .toBe('N/A')
   })
 
   it('has a subtitle', () => {
-    expect(wrapper.find('.ni-data-msg__subtitle div').text().trim())
+    expect(wrapper.find('.ni-data-msg__subtitle h5').text().trim())
       .toBe('No data available yet.')
   })
 })

--- a/test/unit/specs/PageBalances.spec.js
+++ b/test/unit/specs/PageBalances.spec.js
@@ -38,6 +38,7 @@ describe('PageBalances', () => {
   it('should filter the balances', () => {
     store.commit('setSearchVisible', ['balances', true])
     store.commit('setSearchQuery', ['balances', 'atom'])
+    wrapper.update()
     expect(wrapper.vm.filteredBalances.map(x => x.denom)).toEqual(['ATOM'])
     expect(wrapper.vm.$el).toMatchSnapshot()
   })

--- a/test/unit/specs/PageBond.spec.js
+++ b/test/unit/specs/PageBond.spec.js
@@ -58,6 +58,7 @@ describe('PageBond', () => {
   })
 
   it('shows selected candidates', () => {
+    expect(wrapper.vm.fields.delegates.length).toBe(2)
     expect(htmlBeautify(wrapper.html())).toContain('pubkeyX')
     expect(htmlBeautify(wrapper.html())).toContain('pubkeyY')
   })
@@ -65,7 +66,9 @@ describe('PageBond', () => {
   it('should allow removal of candidates', () => {
     global.confirm = jest.fn()
     global.confirm.mockReturnValue(true)
+    expect(wrapper.vm.fields.delegates.length).toBe(2)
     wrapper.findAll('button.remove').at(0).trigger('click')
+    expect(wrapper.vm.fields.delegates.length).toBe(1)
 
     expect(global.confirm).toHaveBeenCalled()
     expect(htmlBeautify(wrapper.html())).not.toContain('pubkeyX')

--- a/test/unit/specs/PageDelegates.spec.js
+++ b/test/unit/specs/PageDelegates.spec.js
@@ -66,6 +66,7 @@ describe('PageDelegates', () => {
     store.commit('setSearchVisible', ['delegates', true])
     store.commit('setSearchQuery', ['delegates', 'dateX'])
     expect(wrapper.vm.filteredDelegates.map(x => x.id)).toEqual(['pubkeyX'])
+    wrapper.update()
     expect(wrapper.vm.$el).toMatchSnapshot()
     store.commit('setSearchQuery', ['delegates', 'dateY'])
     expect(wrapper.vm.filteredDelegates.map(x => x.id)).toEqual(['pubkeyY'])

--- a/test/unit/specs/__snapshots__/NiDataEmpty.spec.js.snap
+++ b/test/unit/specs/__snapshots__/NiDataEmpty.spec.js.snap
@@ -7,14 +7,14 @@ exports[`NiDataEmpty has the expected html structure 1`] = `
    </div>
 <div class=\\"ni-data-msg__text\\">
    <div class=\\"ni-data-msg__title\\">
-      <div>
+      <h4>
          N/A
-      </div>
+      </h4>
 </div>
 <div class=\\"ni-data-msg__subtitle\\">
-   <div>
+   <h5>
       No data available yet.
-   </div>
+   </h5>
 </div>
 </div>
 </div>"

--- a/test/unit/specs/__snapshots__/PageBalances.spec.js.snap
+++ b/test/unit/specs/__snapshots__/PageBalances.spec.js.snap
@@ -465,7 +465,7 @@ exports[`PageBalances should filter the balances 1`] = `
         >
           <!---->
           <a
-            class="ni-li ni-li-link"
+            class="ni-li ni-li-link proposal-leave proposal-leave-active"
             href="#/wallet/send"
           >
             <div
@@ -507,7 +507,7 @@ exports[`PageBalances should filter the balances 1`] = `
             </div>
           </a>
           <a
-            class="ni-li ni-li-link"
+            class="ni-li ni-li-link proposal-enter proposal-enter-active"
             href="#/wallet/send"
           >
             <div

--- a/test/unit/specs/__snapshots__/PageBond.spec.js.snap
+++ b/test/unit/specs/__snapshots__/PageBond.spec.js.snap
@@ -99,7 +99,100 @@ exports[`PageBond has the expected html structure 1`] = `
         <!---->
         <main
           class="ni-form-main"
-        />
+        >
+          <div
+            class="ni-form-group"
+          >
+            <!---->
+            <div
+              class="ni-form-group__field"
+            >
+              <label>
+                someVal... - pubkeyX (0%)
+              </label>
+              <div
+                class="ni-field-group"
+              >
+                <input
+                  class="ni-field"
+                  placeholder="Atoms"
+                  step="any"
+                  type="number"
+                />
+                <div
+                  class="ni-field-addon"
+                >
+                  Atoms
+                </div>
+                <button
+                  class="ni-btn remove"
+                  type="button"
+                >
+                  <span
+                    class="ni-btn-container"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="ni-btn-icon material-icons"
+                    >
+                      clear
+                    </i>
+                    <!---->
+                  </span>
+                </button>
+              </div>
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+          <div
+            class="ni-form-group"
+          >
+            <!---->
+            <div
+              class="ni-form-group__field"
+            >
+              <label>
+                someOth... - pubkeyY (0%)
+              </label>
+              <div
+                class="ni-field-group"
+              >
+                <input
+                  class="ni-field"
+                  placeholder="Atoms"
+                  step="any"
+                  type="number"
+                />
+                <div
+                  class="ni-field-addon"
+                >
+                  Atoms
+                </div>
+                <button
+                  class="ni-btn remove"
+                  type="button"
+                >
+                  <span
+                    class="ni-btn-container"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="ni-btn-icon material-icons"
+                    >
+                      clear
+                    </i>
+                    <!---->
+                  </span>
+                </button>
+              </div>
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+        </main>
         <footer
           class="ni-form-footer"
         >

--- a/test/unit/specs/__snapshots__/PageDelegates.spec.js.snap
+++ b/test/unit/specs/__snapshots__/PageDelegates.spec.js.snap
@@ -458,7 +458,7 @@ exports[`PageDelegates should filter the delegates 1`] = `
       </div>
     </div>
     <div
-      class="li-delegate"
+      class="li-delegate ts-li-delegate-leave ts-li-delegate-leave-active"
     >
       <div
         class="li-delegate__values"
@@ -516,7 +516,7 @@ exports[`PageDelegates should filter the delegates 1`] = `
       </div>
     </div>
     <div
-      class="li-delegate"
+      class="li-delegate ts-li-delegate-enter ts-li-delegate-enter-active"
     >
       <div
         class="li-delegate__values"

--- a/test/unit/specs/node.spec.js
+++ b/test/unit/specs/node.spec.js
@@ -15,6 +15,11 @@ describe('LCD Connector', () => {
     global.fetch = fetch
   })
 
+  it('should provide the nodeIP', () => {
+    let node = LCDConnector('1.1.1.1')
+    expect(node.nodeIP).toBe('1.1.1.1')
+  })
+
   it('should return a mockClient if setting COSMOS_UI_ONLY', () => {
     process.env.COSMOS_UI_ONLY = 'true'
     let node = LCDConnector('1.1.1.1')

--- a/test/unit/specs/store/__snapshots__/notification.spec.js.snap
+++ b/test/unit/specs/store/__snapshots__/notification.spec.js.snap
@@ -8,3 +8,49 @@ Object {
   "title": "TitleA",
 }
 `;
+
+exports[`Module: Notification should add a warning object to the store 1`] = `
+Object {
+  "body": "BodyB",
+  "icon": "warning",
+  "time": 1608,
+  "title": "TitleA",
+  "type": "warning",
+}
+`;
+
+exports[`Module: Notification should add an authentication required notification to the store 1`] = `
+Object {
+  "body": "You must sign up or sign in to view that page.",
+  "icon": "error",
+  "time": 1608,
+  "title": "Authentication Required",
+}
+`;
+
+exports[`Module: Notification should add an signin notification to the store 1`] = `
+Object {
+  "body": "Welcome back.",
+  "icon": "mood",
+  "time": 1608,
+  "title": "Signed In",
+}
+`;
+
+exports[`Module: Notification should add an signout notification to the store 1`] = `
+Object {
+  "body": "Come back again soon.",
+  "icon": "exit_to_app",
+  "time": 1608,
+  "title": "Signed Out",
+}
+`;
+
+exports[`Module: Notification should add an signup notification to the store 1`] = `
+Object {
+  "body": "Thank you for signing up.",
+  "icon": "mood",
+  "time": 1608,
+  "title": "Welcome!",
+}
+`;

--- a/test/unit/specs/store/delegates.spec.js
+++ b/test/unit/specs/store/delegates.spec.js
@@ -1,0 +1,84 @@
+import setup from '../../helpers/vuex-setup'
+
+let axios = require('axios')
+
+let instance = setup()
+
+describe('Module: Delegates', () => {
+  let store, node
+
+  beforeEach(() => {
+    let test = instance.shallow()
+    store = test.store
+    node = test.node
+  })
+
+  it('adds delegate to state', () => {
+    store.commit('addDelegate', { pub_key: { data: 'foo' } })
+    expect(store.state.delegates[0]).toEqual({
+      id: 'foo',
+      pub_key: { data: 'foo' }
+    })
+    expect(store.state.delegates.length).toBe(1)
+  })
+
+  it('replaces existing delegate with same id', () => {
+    store.commit('addDelegate', { pub_key: { data: 'foo' }, updated: true })
+    expect(store.state.delegates[0]).toEqual({
+      id: 'foo',
+      pub_key: { data: 'foo' },
+      updated: true
+    })
+    expect(store.state.delegates.length).toBe(1)
+  })
+
+  it('fetches a candidate', async () => {
+    axios.get = jest.fn()
+      .mockReturnValueOnce(Promise.resolve({
+        data: {
+          data: {
+            pub_key: { data: 'foo' },
+            test: 123
+          }
+        }
+      }))
+
+    await store.dispatch('getDelegate', { data: 'foo' })
+    expect(axios.get.mock.calls[0][0]).toBe('http://localhost:8998/query/stake/candidate/foo')
+    expect(store.state.delegates[0].test).toBe(123)
+  })
+
+  it('fetches all candidates', async () => {
+    axios.get = jest.fn()
+      .mockReturnValueOnce(Promise.resolve({
+        data: {
+          data: {
+            pub_key: { data: 'foo' },
+            test: 123
+          }
+        }
+      }))
+      .mockReturnValueOnce(Promise.resolve({
+        data: {
+          data: {
+            pub_key: { data: 'bar' },
+            test: 456
+          }
+        }
+      }))
+
+    node.candidates = jest.fn()
+      .mockReturnValueOnce({
+        data: [
+          { data: 'foo' },
+          { data: 'bar' }
+        ]
+      })
+
+    await store.dispatch('getDelegates')
+    expect(axios.get.mock.calls[0][0]).toBe('http://localhost:8998/query/stake/candidate/foo')
+    expect(axios.get.mock.calls[1][0]).toBe('http://localhost:8998/query/stake/candidate/bar')
+    expect(store.state.delegates[0].test).toBe(123)
+    expect(store.state.delegates[1].test).toBe(456)
+  })
+})

--- a/test/unit/specs/store/delegation.spec.js
+++ b/test/unit/specs/store/delegation.spec.js
@@ -1,0 +1,151 @@
+import Vuex from 'vuex'
+import { createLocalVue } from 'vue-test-utils'
+
+let axios = require('axios')
+const Delegation = require('renderer/vuex/modules/delegation').default
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+describe('Module: Delegations', () => {
+  let store, walletTx
+
+  beforeEach(() => {
+    let node = require('../../helpers/node_mock')
+    walletTx = jest.fn((_, { cb }) => cb(null, {}))
+    store = new Vuex.Store({
+      modules: {
+        delegation: Delegation({ node }),
+        wallet: {
+          actions: {
+            walletTx
+          }
+        }
+      }
+    })
+  })
+
+  it('adds delegate to cart', () => {
+    store.commit('addToCart', { id: 'foo', x: 1 })
+    expect(store.state.delegation.delegates[0]).toEqual({
+      id: 'foo',
+      delegate: { id: 'foo', x: 1 },
+      atoms: 0
+    })
+    expect(store.state.delegation.delegates.length).toBe(1)
+  })
+
+  it('does not add delegate to cart if already exists', () => {
+    store.commit('addToCart', { id: 'foo' })
+    store.commit('addToCart', { id: 'foo', x: 1 })
+    expect(store.state.delegation.delegates[0].id).toBe('foo')
+    expect(store.state.delegation.delegates[0].x).toBe(undefined)
+    expect(store.state.delegation.delegates.length).toBe(1)
+  })
+
+  it('removes delegate from cart', () => {
+    store.commit('addToCart', { id: 'foo' })
+    store.commit('addToCart', { id: 'bar' })
+    store.commit('removeFromCart', 'foo')
+    expect(store.state.delegation.delegates[0]).toEqual({
+      id: 'bar',
+      delegate: { id: 'bar' },
+      atoms: 0
+    })
+    expect(store.state.delegation.delegates.length).toBe(1)
+  })
+
+  it('sets atoms for delegate', () => {
+    store.commit('addToCart', { id: 'foo' })
+    store.commit('setShares', { candidateId: 'foo', value: 123 })
+    expect(store.state.delegation.delegates[0].atoms).toBe(123)
+  })
+
+  it('sets committed atoms for delegate', () => {
+    store.commit('addToCart', { id: 'foo' })
+    store.commit('setCommittedDelegation', { candidateId: 'foo', value: 123 })
+    expect(store.state.delegation.committedDelegates).toEqual({
+      foo: 123
+    })
+  })
+
+  it('sets committed atoms for delegate to 0', () => {
+    store.commit('addToCart', { id: 'foo' })
+    store.commit('setCommittedDelegation', { candidateId: 'foo', value: 123 })
+    store.commit('setCommittedDelegation', { candidateId: 'foo', value: 0 })
+    expect(store.state.delegation.committedDelegates).toEqual({})
+  })
+
+  it('fetches bonded delegates', async () => {
+    axios.get = jest.fn()
+      .mockReturnValueOnce({
+        data: {
+          data: {
+            PubKey: { data: 'foo' },
+            Shares: 123
+          }
+        }
+      })
+      .mockReturnValueOnce({
+        data: {
+          data: {
+            PubKey: { data: 'bar' },
+            Shares: 456
+          }
+        }
+      })
+
+    await store.dispatch('getBondedDelegates', {
+      candidates: [
+        { pub_key: { data: 'foo' } },
+        { pub_key: { data: 'bar' } }
+      ],
+      address: '1234'
+    })
+    expect(axios.get.mock.calls[0][0]).toEqual('http://localhost:8998/query/stake/delegator/1234/foo')
+    expect(axios.get.mock.calls[1][0]).toEqual('http://localhost:8998/query/stake/delegator/1234/bar')
+
+    expect(store.state.delegation.committedDelegates).toEqual({
+      foo: 123,
+      bar: 456
+    })
+  })
+
+  it('submits delegation transaction', async () => {
+    store.commit('setCommittedDelegation', { candidateId: 'bar', value: 123 })
+    store.commit('setCommittedDelegation', { candidateId: 'baz', value: 789 })
+
+    await store.dispatch('submitDelegation', {
+      delegates: [
+        {
+          delegate: { pub_key: { data: 'foo' } },
+          atoms: 123
+        },
+        {
+          delegate: { pub_key: { data: 'bar' } },
+          atoms: 456
+        },
+        {
+          delegate: { pub_key: { data: 'baz' } },
+          atoms: 0
+        }
+      ]
+    })
+    expect(walletTx.mock.calls.length).toBe(3)
+
+    // bonding to a validator we were not previously bonded to
+    expect(walletTx.mock.calls[0][1].amount).toEqual({ amount: 123, denom: 'fermion' })
+    expect(walletTx.mock.calls[0][1].pub_key).toEqual({ data: 'foo' })
+    expect(walletTx.mock.calls[0][1].type).toBe('buildDelegate')
+
+    // bonding to a validator we were previously bonded to
+    expect(walletTx.mock.calls[1][1].amount).toEqual({ amount: 333, denom: 'fermion' })
+    expect(walletTx.mock.calls[1][1].pub_key).toEqual({ data: 'bar' })
+    expect(walletTx.mock.calls[1][1].type).toBe('buildDelegate')
+
+    // unbonding
+    expect(walletTx.mock.calls[2][1].amount).toEqual(789)
+    expect(walletTx.mock.calls[2][1].pub_key).toEqual({ data: 'baz' })
+    expect(walletTx.mock.calls[2][1].type).toBe('buildUnbond')
+  })
+})

--- a/test/unit/specs/store/filters.spec.js
+++ b/test/unit/specs/store/filters.spec.js
@@ -1,0 +1,30 @@
+import setup from '../../helpers/vuex-setup'
+
+let instance = setup()
+
+describe('Module: Filters', () => {
+  let store, state
+
+  beforeEach(() => {
+    store = instance.shallow().store
+    state = store.state.filters
+  })
+
+  it('can set a search type\'s visiblility', () => {
+    expect(state.balances.search.visible).toBe(false)
+
+    store.commit('setSearchVisible', [ 'balances', true ])
+    expect(state.balances.search.visible).toBe(true)
+
+    store.commit('setSearchVisible', [ 'balances', false ])
+    expect(state.balances.search.visible).toBe(false)
+  })
+
+  it('can set a search type\'s query', () => {
+    expect(state.delegates.search.query).toBe('')
+
+    store.commit('setSearchQuery', [ 'delegates', 'validator1' ])
+    expect(state.delegates.search.query).toBe('validator1')
+    expect(state.proposals.search.query).toBe('')
+  })
+})

--- a/test/unit/specs/store/index.spec.js
+++ b/test/unit/specs/store/index.spec.js
@@ -1,0 +1,17 @@
+let Modules = require('renderer/vuex/modules').default
+let node = require('../../helpers/node_mock')
+
+describe('Module Index', () => {
+  it('can be instantiated', () => {
+    let modules = Modules({ node })
+
+    // check modules for correct export interface
+    for (let moduleName in modules) {
+      let module = modules[moduleName]
+      for (let key in module) {
+        let vuexModuleKeys = [ 'state', 'mutations', 'actions' ]
+        expect(vuexModuleKeys.includes(key)).toBe(true)
+      }
+    }
+  })
+})

--- a/test/unit/specs/store/notification.spec.js
+++ b/test/unit/specs/store/notification.spec.js
@@ -24,4 +24,42 @@ describe('Module: Notification', () => {
     expect(store.state.notifications.length).toBe(1)
     expect(store.state.notifications[0]).toMatchSnapshot()
   })
+
+  it('should add a warning object to the store', () => {
+    store.commit('notifyWarn', {
+      title: 'TitleA',
+      body: 'BodyB'
+    })
+    expect(store.state.notifications.length).toBe(1)
+    expect(store.state.notifications[0]).toMatchSnapshot()
+  })
+
+  it('should add an signup notification to the store', () => {
+    store.commit('notifySignUp')
+    expect(store.state.notifications.length).toBe(1)
+    expect(store.state.notifications[0]).toMatchSnapshot()
+  })
+
+  it('should add an signin notification to the store', () => {
+    store.commit('notifySignIn')
+    expect(store.state.notifications.length).toBe(1)
+    expect(store.state.notifications[0]).toMatchSnapshot()
+  })
+
+  it('should add an signout notification to the store', () => {
+    store.commit('notifySignOut')
+    expect(store.state.notifications.length).toBe(1)
+    expect(store.state.notifications[0]).toMatchSnapshot()
+  })
+
+  it('should add an authentication required notification to the store', () => {
+    store.commit('notifyAuthRequired')
+    expect(store.state.notifications.length).toBe(1)
+    expect(store.state.notifications[0]).toMatchSnapshot()
+
+    // allow body to be defined to give user source of auth decline
+    store.commit('notifyAuthRequired', 'Some text')
+    expect(store.state.notifications.length).toBe(2)
+    expect(store.state.notifications[1].body).toBe('Some text')
+  })
 })

--- a/test/unit/specs/store/user.spec.js
+++ b/test/unit/specs/store/user.spec.js
@@ -1,0 +1,152 @@
+import setup from '../../helpers/vuex-setup'
+
+let instance = setup()
+
+describe('Module: User', () => {
+  let store, node
+  let accounts = [{
+    address: '1234567890123456789012345678901234567890',
+    name: 'ACTIVE_ACCOUNT',
+    password: '1234567890'
+  }]
+
+  beforeEach(() => {
+    let test = instance.shallow()
+    store = test.store
+    node = test.node
+  })
+
+  it('should default to signed out state', () => {
+    expect(store.state.user.signedIn).toBe(false)
+    expect(store.state.user.password).toBe(null)
+    expect(store.state.user.account).toBe(null)
+    expect(store.state.user.address).toBe(null)
+  })
+
+  it('should set accounts', () => {
+    store.commit('setAccounts', accounts)
+    expect(store.state.user.accounts).toEqual(accounts)
+  })
+
+  it('should show an error if loading accounts fails', async () => {
+    node.listKeys = () => Promise.reject('Expected Error')
+    await store.dispatch('loadAccounts')
+    expect(store.state.notifications[0].title).toBe(`Couldn't read keys`)
+  })
+
+  it('should set atoms', () => {
+    store.commit('setAtoms', 42)
+    expect(store.state.user.atoms).toBe(42)
+  })
+
+  it('should prepare the signin', async () => {
+    node.listKeys = () => Promise.resolve(accounts)
+    await store.dispatch('showInitialScreen')
+    expect(store.state.config.modals.session.state).toBe('sign-in')
+    expect(store.state.config.modals.session.active).toBe(true)
+  })
+
+  it('should show a welcome screen if there are no accounts yet', async () => {
+    node.listKeys = () => Promise.resolve([])
+    await store.dispatch('showInitialScreen')
+    expect(store.state.config.modals.session.state).toBe('welcome')
+    expect(store.state.config.modals.session.active).toBe(true)
+  })
+
+  it('should test if the login works', async () => {
+    node.updateKey = (account, {name, password, new_passphrase}) => {
+      expect(account).toBe(name)
+      expect(password).toBe(new_passphrase)
+      return true
+    }
+    let output = await store.dispatch('testLogin', {
+      account: 'ABC',
+      details: {
+        name: 'ABC',
+        password: '123',
+        new_passphrase: '123'
+      }
+    })
+    expect(output).toBe(true)
+  })
+
+  it('should raise an error if login test fails', done => {
+    node.updateKey = () => Promise.reject('Expected error')
+    store.dispatch('testLogin', {}).catch(() => done())
+  })
+
+  it('should create a seed phrase', async () => {
+    let seed = await store.dispatch('createSeed')
+    expect(seed).toBeDefined()
+    expect(seed.split(' ').length).toBe(12)
+  })
+
+  it('should delete an existing trunc when generating a seed phrase', done => {
+    node.listKeys = () => Promise.resolve([{name: 'trunk'}])
+    node.deleteKey = (account) => {
+      expect(account).toBe('trunk')
+      done()
+    }
+    store.dispatch('createSeed')
+  })
+
+  it('should create a key from a seed phrase', async () => {
+    let seedPhrase = 'abc'
+    let password = '123'
+    let name = 'def'
+    node.recoverKey = jest.fn(() => ({key: {
+      address: 'some address'
+    }}))
+    let key = await store.dispatch('createKey', { seedPhrase, password, name })
+    expect(node.recoverKey).toHaveBeenCalledWith({
+      seed_phrase: seedPhrase,
+      password,
+      name
+    })
+    expect(key).toEqual({
+      address: 'some address'
+    })
+
+    // initialize wallet
+    expect(store.state.wallet.key).toEqual({
+      address: 'some address'
+    })
+  })
+
+  it('should delete a key', async () => {
+    let password = '123'
+    let name = 'def'
+    node.deleteKey = jest.fn()
+    await store.dispatch('deleteKey', { password, name })
+    expect(node.deleteKey).toHaveBeenCalledWith(name, { password, name })
+  })
+
+  it('should sign in', async () => {
+    let password = '123'
+    let account = 'def'
+    node.getKey = jest.fn(() => Promise.resolve({
+      address: 'some address'
+    }))
+    await store.dispatch('signIn', { password, account })
+    expect(node.getKey).toHaveBeenCalledWith(account)
+    expect(store.state.user.signedIn).toBe(true)
+
+    // initialize wallet
+    expect(store.state.wallet.key).toEqual({
+      address: 'some address'
+    })
+
+    // hide login
+    expect(store.state.config.modals.session.active).toBe(false)
+  })
+
+  it('should sign out', () => {
+    store.dispatch('signOut')
+    expect(store.state.user.account).toBe(null)
+    expect(store.state.user.password).toBe(null)
+    expect(store.state.user.signedIn).toBe(false)
+
+    // hide login
+    expect(store.state.config.modals.session.active).toBe(true)
+  })
+})


### PR DESCRIPTION
closes #29 

>User is able to see the node up time for every node in the network for last [day, week, month, year?]

i don't think this info is particularly important as part of the netmon. this is info that should matter for a validator / candidate. i'd propose to cross this off the list above.

>User is able to see the amount of currently active node?

i'd propose this be moved to the footer — also, is there any way we can actually get this data? right now it's just `validators.length` which is not the same as "active nodes".

1. i'd like to propose that we switch the word in the sidebar from 'Monitor' to 'Blocks'. this page will then show a list of blocks, each one clickable, taking the user to the PageBlock for that block. this would be fairly simple to implement and should be called the "block explorer" not "network monitor".

2. "the network monitor" is the graphical interface with fancy visualizations which really has nothing to do with this PR (and as discussed requires some re-designing). i'd like to propose that we leave this visualization tool (AKA Netmon) until post launch. i would love to have it but it does not seem vital for pre-launch.

3. if we feel we want to show the version numbers in the app as seen below, i'd recommend that we put them in the native menu under an 'about' section. if we show any version numbers, we ougght to show all of them (tendermint, abci?, gaia / hub, ui) but arguably, we don't need to share version numbers. i'd propose to remove them altogether.

```
ABCI Version
0.7.1
Tendermint Version
0.13.0
```
  