### PR TITLE
Peng/320 fix overflow x

### DIFF
--- a/app/src/renderer/styles/app.styl
+++ b/app/src/renderer/styles/app.styl
@@ -28,6 +28,7 @@ a
   padding-top 3rem
   height 100vh
   width 100vw
+  max-width 100%
 
   display flex
   flex-flow column nowrap
@@ -66,6 +67,9 @@ a
     flex 1
     display flex
     flex-flow column no-wrap
+
+    overflow hidden
+    position relative
 
  .desktop-only
     display block

--- a/app/src/renderer/styles/app.styl
+++ b/app/src/renderer/styles/app.styl
@@ -68,8 +68,5 @@ a
     display flex
     flex-flow column no-wrap
 
-    overflow hidden
-    position relative
-
  .desktop-only
     display block


### PR DESCRIPTION
App no longer overflows past 100% when scrollbars are visible.

![screen shot 2018-01-12 at 2 43 36 pm](https://user-images.githubusercontent.com/172531/34861315-513936f2-f7a7-11e7-9728-06ef111dd937.png)


Closes #320