### PR TITLE
Simplify build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,7 @@
     "test:unit": "cross-env LOGGING=false MOCK=false jest --maxWorkers=2",
     "test:e2e": "tape \"test/e2e/!(main)*.js\"",
     "vue:route": "node tasks/vue/route.js",
-    "vuex:module": "node tasks/vuex/module.js",
-    "rebuild": "electron-rebuild",
-    "postinstall": "npm run rebuild"
+    "vuex:module": "node tasks/vuex/module.js"
   },
   "devDependencies": {
     "babel-core": "^6.8.0",
@@ -57,7 +55,6 @@
     "electron-debug": "^1.4.0",
     "electron-devtools-installer": "^2.1.0",
     "electron-packager": "^10.1.0",
-    "electron-rebuild": "^1.5.7",
     "eslint": "^3.13.1",
     "eslint-config-standard": "^6.2.1",
     "eslint-friendly-formatter": "^2.0.5",

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -3,7 +3,6 @@
 const { exec } = require('child_process')
 const { join } = require('path')
 const packager = require('electron-packager')
-const rebuild = require('electron-rebuild').default
 const mkdirp = require('mkdirp').sync
 const fs = require('fs-extra')
 const { promisify } = require('util')
@@ -63,15 +62,6 @@ function build () {
 
   options.afterCopy = [
     copyBinary('gaia', binaryPath)
-  ]
-  // prune installs the packages
-  options.afterPrune = [
-    // we need to rebuild some native packages for the electron environment
-    function rebuildNodeModules (buildPath, electronVersion, platform, arch, callback) {
-      rebuild({ buildPath, electronVersion, arch })
-        .then(callback)
-        .catch(callback)
-    }
   ]
 
   console.log('\x1b[34mBuilding electron app(s)...\n\x1b[0m')

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -21,6 +21,13 @@ process.argv.forEach(function (val) {
   }
 })
 
+if (!binaryPath) {
+  console.error(`\x1b[31mPlease specify a gaia binary for this platform using the "--binary" flag
+    Example: npm run build:darwin -- --binary=./gaia
+    \x1b[0m`)
+  process.exit(1)
+}
+
 if (process.env.PLATFORM_TARGET === 'clean') {
   require('del').sync(['builds/*', '!.gitkeep'])
   console.log('\x1b[33m`builds` directory cleaned.\n\x1b[0m')
@@ -55,9 +62,7 @@ function build () {
   let options = require('../config').building
 
   options.afterCopy = [
-    binaryPath
-      ? copyBinary('gaia', binaryPath)
-      : buildGaiaBinary()
+    copyBinary('gaia', binaryPath)
   ]
   // prune installs the packages
   options.afterPrune = [
@@ -91,46 +96,5 @@ function copyBinary (name, binaryLocation) {
     }
     fs.copySync(binaryLocation, binPath)
     cb()
-  }
-}
-
-const GOARCH = {
-  'x64': 'amd64',
-  'ia32': '386'
-}
-
-function buildGaiaBinary () {
-  return function (buildPath, electronVersion, platform, arch, cb) {
-    if (platform === 'win32') platform = 'windows'
-    if (platform === 'mas') platform = 'darwin'
-    if (GOARCH[arch]) arch = GOARCH[arch]
-
-    console.log(`\x1b[34mBuilding gaia binary (${platform}/${arch})...\n\x1b[0m`)
-
-    let output = 'gaia'
-    if (platform === 'windows') output += '.exe'
-
-    let cmd = `
-      docker run -v "/tmp:/mnt" golang bash -c "
-        go get github.com/cosmos/gaia;
-        cd /go/src/github.com/cosmos/gaia && \
-        git checkout develop && \
-        make get_vendor_deps && \
-        GOOS=${platform} GOARCH=${arch} go build \
-          -o /mnt/${output} \
-          -ldflags '-s -w' \
-          ./cmd/gaia
-      "
-    `
-    let docker = exec(cmd)
-    docker.stdout.on('data', (data) => process.stdout.write(data))
-    docker.stderr.on('data', (data) => process.stderr.write(data))
-    docker.once('exit', (code) => {
-      if (code !== 0) return cb(Error('Build failed'))
-
-      let binPath = join(buildPath, 'bin')
-      mkdirp(binPath)
-      fs.copy(join('/tmp', output), join(binPath, output), cb)
-    })
   }
 }


### PR DESCRIPTION
In this PR:
- Removed the gaia binary build script (closes #340 and #341)
- Removed the electron-rebuild step, which was breaking the builds (we don't need the native modules anyway)