### PR TITLE
Peng/289 improve page delegates

### DIFF
--- a/app/src/renderer/components/common/NiPage.vue
+++ b/app/src/renderer/components/common/NiPage.vue
@@ -55,6 +55,8 @@ export default {
 .ni-page-main
   flex 1
   position relative
+  display flex
+  flex-flow column nowrap
 
 .ni-page-title
   color bright

--- a/app/src/renderer/components/staking/LiDelegate.vue
+++ b/app/src/renderer/components/staking/LiDelegate.vue
@@ -5,11 +5,8 @@
     i.fa.fa-square-o(v-else @click='add(delegate)')
   .li-delegate__value.name
     span
-      router-link(v-if="config.devMode" :to="{ name: 'delegate', params: { delegate: delegate.id }}")
-        | {{ ' ' + delegate.moniker }}
+      router-link(v-if="config.devMode" :to="{ name: 'delegate', params: { delegate: delegate.id }}")  {{ ' ' + delegate.moniker }}
       a(v-else) {{ ' ' + delegate.moniker }}
-  .li-delegate__value.id
-    span {{ delegate.id }}
   .li-delegate__value.percent_of_vote
     span {{ num.percentInt(bondedPercent) }}
   .li-delegate__value.number_of_votes.num.bar
@@ -89,7 +86,7 @@ export default {
   height 3rem
 
 .li-delegate__value
-  flex 3
+  flex 1
   display flex
   align-items center
   min-width 0
@@ -97,16 +94,8 @@ export default {
   &:first-child
     flex 0.5
 
-  &.name
+  &.number_of_votes
     flex 2
-
-  &.id
-    flex 2
-
-  &.percent_of_vote,
-  &.number_of_votes,
-  &.bonded_by_you
-    flex 1
 
   &.id span
     i.fa

--- a/app/src/renderer/components/staking/PageDelegates.vue
+++ b/app/src/renderer/components/staking/PageDelegates.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-page(title='Delegates')
+page#page-delegates(title='Delegates')
   div(slot="menu"): tool-bar
     a(@click='setSearch(true)')
       i.material-icons search
@@ -10,14 +10,15 @@ page(title='Delegates')
 
   modal-search(type="delegates")
 
-  data-error(v-if="delegates.length === 0")
-  data-empty-search(v-else-if="filteredDelegates.length === 0")
-  div.delegate-container(v-else)
-    panel-sort(:sort='sort')
-    li-delegate(v-for='i in filteredDelegates' :key='i.id' :delegate='i')
+  .delegates-container
+    data-error(v-if="delegates.length === 0")
+    data-empty-search(v-else-if="filteredDelegates.length === 0")
+    template(v-else)
+      panel-sort(:sort='sort')
+      li-delegate(v-for='i in filteredDelegates' :key='i.id' :delegate='i')
 
-  div.fixed-button-bar
-    h3 <b>{{ shoppingCart.length }}</b> selected
+  .fixed-button-bar
+    .label #[strong {{ shoppingCart.length }}] delegates selected
     btn.btn__primary(type="link" to="/staking/bond" :disabled="shoppingCart.length < 1" icon="chevron_right" icon-pos="right" value="Next")
 </template>
 
@@ -77,10 +78,9 @@ export default {
       properties: [
         { id: 0, title: '', value: '' },
         { id: 1, title: 'Name', value: 'description.moniker', class: 'name' },
-        { id: 2, title: 'Public Key', value: 'id', class: 'id' },
-        { id: 3, title: '% of Vote', value: 'shares', class: 'percent_of_vote' },
-        { id: 4, title: '# of Votes', value: 'voting_power', class: 'number_of_votes' },
-        { id: 5, title: 'Bonded by You', value: 'bonded', class: 'bonded_by_you' }
+        { id: 2, title: '% of Vote', value: 'shares', class: 'percent_of_vote' },
+        { id: 3, title: '# of Votes', value: 'voting_power', class: 'number_of_votes' },
+        { id: 4, title: 'Bonded by You', value: 'bonded', class: 'bonded_by_you' }
       ]
     }
   }),
@@ -106,27 +106,18 @@ export default {
 <style lang="stylus">
 @require '~variables'
 
-.action-container
-  padding 1rem 0 1rem 1rem
-  min-height 5rem
+.delegates-container
+  flex 1
 
 .fixed-button-bar
-  position absolute
   width 100%
-  background app-bg
-  bottom calc(3rem + 1px)
-  left 0
-  bottom 0
   padding 1rem
+  background app-fg
   display flex
   justify-content space-between
-  border-top 1px solid bc
-
-@media screen and (max-width: 768px)
-  .delegate-container
-    padding 0.5rem
-
-  .li-delegate__value
-    &.id
-      display none
+  .label
+    color bright
+    line-height 2rem
+    strong
+      font-weight bold
 </style>

--- a/app/src/renderer/components/staking/PanelSort.vue
+++ b/app/src/renderer/components/staking/PanelSort.vue
@@ -45,7 +45,7 @@ export default {
   border-bottom px solid bc
 
 .sort-by
-  flex 3
+  flex 1
   cursor pointer
   user-select none
   display flex
@@ -54,7 +54,7 @@ export default {
   min-width 0
 
   &:first-child
-    flex 0.5 1 0%;
+    flex 0.5
 
   .label
     font-size sm
@@ -86,16 +86,8 @@ export default {
     &:after
       color txt
 
-  &.name
+  &.number_of_votes
     flex 2
-
-  &.id
-    flex 2
-
-  &.percent_of_vote,
-  &.number_of_votes,
-  &.bonded_by_you
-    flex 1
 
 @media screen and (max-width: 768px)
   .sort-by

--- a/app/src/renderer/styles/app.styl
+++ b/app/src/renderer/styles/app.styl
@@ -47,6 +47,11 @@ a
 .ni-field
   border-radius 2px!important
 
+#app-content
+  flex 1
+  display flex
+  flex-flow column no-wrap
+
 @media screen and (min-width: 1024px)
   #app
     padding-top 0
@@ -72,11 +77,6 @@ a
       line-height: normal
       img
         height 1.25rem
-
-  #app-content
-    flex 1
-    display flex
-    flex-flow column no-wrap
 
  .desktop-only
     display block

--- a/test/unit/specs/PageDelegates.spec.js
+++ b/test/unit/specs/PageDelegates.spec.js
@@ -77,7 +77,7 @@ describe('PageDelegates', () => {
     store.commit('addToCart', store.state.delegates[0])
     store.commit('addToCart', store.state.delegates[1])
     wrapper.update()
-    expect(htmlBeautify(wrapper.html())).toContain('<b>2</b> selected')
+    expect(wrapper.find('.fixed-button-bar strong').text().trim()).toContain('2')
   })
 
   it('should show an error if there are no delegates', () => {

--- a/test/unit/specs/PageDelegates.spec.js
+++ b/test/unit/specs/PageDelegates.spec.js
@@ -42,7 +42,7 @@ describe('PageDelegates', () => {
   })
 
   it('has the expected html structure', () => {
-    expect(wrapper.vm.$el).toMatchSnapshot()
+    expect(htmlBeautify(wrapper.html())).toMatchSnapshot()
   })
 
   it('should show the search on click', () => {

--- a/test/unit/specs/__snapshots__/LiDelegate.spec.js.snap
+++ b/test/unit/specs/__snapshots__/LiDelegate.spec.js.snap
@@ -22,15 +22,8 @@ exports[`LiDelegate has the expected html structure 1`] = `
           class=""
           href="#/staking/delegates/pubkeyX"
         >
-           candidateX
+            candidateX
         </a>
-      </span>
-    </div>
-    <div
-      class="li-delegate__value id"
-    >
-      <span>
-        pubkeyX
       </span>
     </div>
     <div

--- a/test/unit/specs/__snapshots__/PageDelegates.spec.js.snap
+++ b/test/unit/specs/__snapshots__/PageDelegates.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`PageDelegates has the expected html structure 1`] = `
 <div
   class="ni-page"
+  id="page-delegates"
 >
   <header
     class="ni-page-header"
@@ -88,7 +89,7 @@ exports[`PageDelegates has the expected html structure 1`] = `
   >
     <!---->
     <div
-      class="delegate-container"
+      class="delegates-container"
     >
       <div
         class="panel-sort"
@@ -112,15 +113,6 @@ exports[`PageDelegates has the expected html structure 1`] = `
               class="label"
             >
               Name
-            </div>
-          </div>
-          <div
-            class="sort-by id"
-          >
-            <div
-              class="label"
-            >
-              Public Key
             </div>
           </div>
           <div
@@ -173,15 +165,8 @@ exports[`PageDelegates has the expected html structure 1`] = `
                 class=""
                 href="#/staking/delegates/pubkeyY"
               >
-                 candidateY
+                  candidateY
               </a>
-            </span>
-          </div>
-          <div
-            class="li-delegate__value id"
-          >
-            <span>
-              pubkeyY
             </span>
           </div>
           <div
@@ -232,15 +217,8 @@ exports[`PageDelegates has the expected html structure 1`] = `
                 class=""
                 href="#/staking/delegates/pubkeyX"
               >
-                 candidateX
+                  candidateX
               </a>
-            </span>
-          </div>
-          <div
-            class="li-delegate__value id"
-          >
-            <span>
-              pubkeyX
             </span>
           </div>
           <div
@@ -274,12 +252,14 @@ exports[`PageDelegates has the expected html structure 1`] = `
     <div
       class="fixed-button-bar"
     >
-      <h3>
-        <b>
+      <div
+        class="label"
+      >
+        <strong>
           0
-        </b>
-         selected
-      </h3>
+        </strong>
+         delegates selected
+      </div>
       <a
         class="ni-btn btn__primary"
         disabled="disabled"
@@ -309,6 +289,7 @@ exports[`PageDelegates has the expected html structure 1`] = `
 exports[`PageDelegates should filter the delegates 1`] = `
 <div
   class="ni-page"
+  id="page-delegates"
 >
   <header
     class="ni-page-header"
@@ -421,7 +402,7 @@ exports[`PageDelegates should filter the delegates 1`] = `
       </div>
     </div>
     <div
-      class="delegate-container"
+      class="delegates-container"
     >
       <div
         class="panel-sort"
@@ -445,15 +426,6 @@ exports[`PageDelegates should filter the delegates 1`] = `
               class="label"
             >
               Name
-            </div>
-          </div>
-          <div
-            class="sort-by id"
-          >
-            <div
-              class="label"
-            >
-              Public Key
             </div>
           </div>
           <div
@@ -506,15 +478,8 @@ exports[`PageDelegates should filter the delegates 1`] = `
                 class=""
                 href="#/staking/delegates/pubkeyX"
               >
-                 candidateX
+                  candidateX
               </a>
-            </span>
-          </div>
-          <div
-            class="li-delegate__value id"
-          >
-            <span>
-              pubkeyX
             </span>
           </div>
           <div
@@ -548,12 +513,14 @@ exports[`PageDelegates should filter the delegates 1`] = `
     <div
       class="fixed-button-bar"
     >
-      <h3>
-        <b>
+      <div
+        class="label"
+      >
+        <strong>
           0
-        </b>
-         selected
-      </h3>
+        </strong>
+         delegates selected
+      </div>
       <a
         class="ni-btn btn__primary"
         disabled="disabled"

--- a/test/unit/specs/__snapshots__/PageDelegates.spec.js.snap
+++ b/test/unit/specs/__snapshots__/PageDelegates.spec.js.snap
@@ -1,289 +1,122 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PageDelegates has the expected html structure 1`] = `
-<div
-  class="ni-page"
-  id="page-delegates"
->
-  <header
-    class="ni-page-header"
-  >
-    <div
-      class="ni-page-header-container"
-    >
-      <div
-        class="ni-page-header-text"
-      >
-        <div
-          class="ni-page-header-title"
-        >
-          <h2>
-            Delegates
-          </h2>
-        </div>
-        <div
-          class="ni-page-header-subtitle"
-        >
-          <h3>
-            
-          </h3>
-        </div>
-      </div>
-      <menu
-        class="ni-page-header-menu"
-      >
-        <div>
-          <div>
-            <div
-              class="ni-tool-bar"
-            >
-              <div
-                class="ni-tool-bar-container"
-              >
-                <div
-                  class="main"
-                >
-                  <a>
-                    <i
-                      class="material-icons"
-                    >
-                      search
-                    </i>
-                    <div
-                      class="label"
-                    >
-                      Search
-                    </div>
-                  </a>
-                  <a>
-                    <i
-                      class="material-icons"
-                    >
-                      refresh
-                    </i>
-                    <div
-                      class="label"
-                    >
-                      Refresh
-                    </div>
-                  </a>
-                </div>
-                <a
-                  class="help"
-                >
-                  <i
-                    class="material-icons"
-                  >
-                    help_outline
-                  </i>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </menu>
-    </div>
-  </header>
-  <main
-    class="ni-page-main"
-  >
-    <!---->
-    <div
-      class="delegates-container"
-    >
-      <div
-        class="panel-sort"
-      >
-        <div
-          class="panel-sort-container"
-        >
-          <div
-            class="sort-by"
-          >
-            <div
-              class="label"
-            >
-              
-            </div>
-          </div>
-          <div
-            class="sort-by name"
-          >
-            <div
-              class="label"
-            >
-              Name
-            </div>
-          </div>
-          <div
-            class="sort-by percent_of_vote"
-          >
-            <div
-              class="label"
-            >
-              % of Vote
-            </div>
-          </div>
-          <div
-            class="sort-by number_of_votes"
-          >
-            <div
-              class="label"
-            >
-              # of Votes
-            </div>
-          </div>
-          <div
-            class="sort-by bonded_by_you"
-          >
-            <div
-              class="label"
-            >
-              Bonded by You
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="li-delegate"
-      >
-        <div
-          class="li-delegate__values"
-        >
-          <div
-            class="li-delegate__value checkbox"
-          >
-            <i
-              class="fa fa-square-o"
-            />
-          </div>
-          <div
-            class="li-delegate__value name"
-          >
-            <span>
-              <a
-                class=""
-                href="#/staking/delegates/pubkeyY"
-              >
-                  candidateY
-              </a>
-            </span>
-          </div>
-          <div
-            class="li-delegate__value percent_of_vote"
-          >
-            <span>
-              75%
-            </span>
-          </div>
-          <div
-            class="li-delegate__value number_of_votes num bar"
-          >
-            <span>
-              30,000
-            </span>
-            <div
-              class="bar"
-              style="width: 100%;"
-            />
-          </div>
-          <div
-            class="li-delegate__value bonded_by_you"
-          >
-            <span>
-              0
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="li-delegate"
-      >
-        <div
-          class="li-delegate__values"
-        >
-          <div
-            class="li-delegate__value checkbox"
-          >
-            <i
-              class="fa fa-square-o"
-            />
-          </div>
-          <div
-            class="li-delegate__value name"
-          >
-            <span>
-              <a
-                class=""
-                href="#/staking/delegates/pubkeyX"
-              >
-                  candidateX
-              </a>
-            </span>
-          </div>
-          <div
-            class="li-delegate__value percent_of_vote"
-          >
-            <span>
-              25%
-            </span>
-          </div>
-          <div
-            class="li-delegate__value number_of_votes num bar"
-          >
-            <span>
-              10,000
-            </span>
-            <div
-              class="bar"
-              style="width: 33%;"
-            />
-          </div>
-          <div
-            class="li-delegate__value bonded_by_you"
-          >
-            <span>
-              0
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="fixed-button-bar"
-    >
-      <div
-        class="label"
-      >
-        <strong>
-          0
-        </strong>
-         delegates selected
-      </div>
-      <a
-        class="ni-btn btn__primary"
-        disabled="disabled"
-        href="#/staking/bond"
-      >
-        <span
-          class="ni-btn-container ni-btn-icon-right"
-        >
-          <i
-            aria-hidden="true"
-            class="ni-btn-icon material-icons"
-          >
-            chevron_right
-          </i>
-          <span
-            class="ni-btn-value"
-          >
-            Next
-          </span>
-        </span>
-      </a>
-    </div>
-  </main>
+"<div class=\\"ni-page\\" id=\\"page-delegates\\">
+   <header class=\\"ni-page-header\\">
+      <div class=\\"ni-page-header-container\\">
+         <div class=\\"ni-page-header-text\\">
+            <div class=\\"ni-page-header-title\\">
+               <h2>
+                  Delegates
+               </h2>
 </div>
+   <div class=\\"ni-page-header-subtitle\\">
+      <h3></h3>
+</div>
+</div>
+   <menu class=\\"ni-page-header-menu\\">
+      <div>
+         <div>
+            <div class=\\"ni-tool-bar\\">
+               <div class=\\"ni-tool-bar-container\\">
+                  <div class=\\"main\\">
+                     <a><i class=\\"material-icons\\">search</i>
+                     <div class=\\"label\\">
+                        Search
+                     </div>
+      </a><a><i class=\\"material-icons\\">refresh</i>
+      <div class=\\"label\\">
+         Refresh
+      </div>
+      </a>
+   </div>
+      <a class=\\"help\\"><i class=\\"material-icons\\">help_outline</i></a>
+   </div>
+</div>
+</div>
+</div>
+</menu>
+</div>
+</header>
+<main class=\\"ni-page-main\\">
+   <!---->
+   <div class=\\"delegates-container\\">
+      <div class=\\"panel-sort\\">
+         <div class=\\"panel-sort-container\\">
+            <div class=\\"sort-by\\">
+               <div class=\\"label\\"></div>
+</div>
+   <div class=\\"sort-by name\\">
+      <div class=\\"label\\">
+         Name
+      </div>
+</div>
+   <div class=\\"sort-by percent_of_vote\\">
+      <div class=\\"label\\">
+         % of Vote
+      </div>
+</div>
+   <div class=\\"sort-by number_of_votes\\">
+      <div class=\\"label\\">
+         # of Votes
+      </div>
+</div>
+   <div class=\\"sort-by bonded_by_you\\">
+      <div class=\\"label\\">
+         Bonded by You
+      </div>
+</div>
+</div>
+</div>
+   <div class=\\"li-delegate\\">
+      <div class=\\"li-delegate__values\\">
+         <div class=\\"li-delegate__value checkbox\\">
+            <i class=\\"fa fa-square-o\\"></i>
+         </div>
+   <div class=\\"li-delegate__value name\\">
+      <span><a href=\\"#/staking/delegates/pubkeyY\\" class=\\"\\">  candidateY</a></span>
+   </div>
+   <div class=\\"li-delegate__value percent_of_vote\\">
+      <span>75%</span>
+   </div>
+   <div class=\\"li-delegate__value number_of_votes num bar\\">
+      <span>30,000</span>
+      <div class=\\"bar\\" style=\\"width: 100%;\\"></div>
+</div>
+   <div class=\\"li-delegate__value bonded_by_you\\">
+      <span>0</span>
+   </div>
+</div>
+</div>
+   <div class=\\"li-delegate\\">
+      <div class=\\"li-delegate__values\\">
+         <div class=\\"li-delegate__value checkbox\\">
+            <i class=\\"fa fa-square-o\\"></i>
+         </div>
+   <div class=\\"li-delegate__value name\\">
+      <span><a href=\\"#/staking/delegates/pubkeyX\\" class=\\"\\">  candidateX</a></span>
+   </div>
+   <div class=\\"li-delegate__value percent_of_vote\\">
+      <span>25%</span>
+   </div>
+   <div class=\\"li-delegate__value number_of_votes num bar\\">
+      <span>10,000</span>
+      <div class=\\"bar\\" style=\\"width: 33%;\\"></div>
+</div>
+   <div class=\\"li-delegate__value bonded_by_you\\">
+      <span>0</span>
+   </div>
+</div>
+</div>
+</div>
+   <div class=\\"fixed-button-bar\\">
+      <div class=\\"label\\">
+         <strong>0</strong> delegates selected
+      </div>
+   <a href=\\"#/staking/bond\\" class=\\"ni-btn btn__primary\\" disabled=\\"disabled\\"><span class=\\"ni-btn-container ni-btn-icon-right\\"><i aria-hidden=\\"true\\" class=\\"ni-btn-icon material-icons\\">chevron_right</i><span class=\\"ni-btn-value\\">Next</span></span></a>
+</div>
+</main>
+</div>"
 `;
 
 exports[`PageDelegates should filter the delegates 1`] = `


### PR DESCRIPTION
* hides the delegate's id, because it's too long to digest and the moniker should be unique
* fixes the `.fixed-button-bar` to the bottom of the page
* simplified some of the CSS

Closes #289 

## Old

<img width="404" alt="screen shot 2018-01-15 at 12 57 28 pm" src="https://user-images.githubusercontent.com/172531/34928114-5966b9ac-f9f6-11e7-810f-514ebb7579fd.png">

## New

<img width="592" alt="screen shot 2018-01-15 at 1 09 09 pm" src="https://user-images.githubusercontent.com/172531/34928118-5fb0d662-f9f6-11e7-8138-394a9cbcc2c1.png">
