### PR TITLE
Peng/297 set max width

### DIFF
--- a/app/src/renderer/components/common/NiFormGroup.vue
+++ b/app/src/renderer/components/common/NiFormGroup.vue
@@ -23,9 +23,6 @@ export default {
 
 <style lang="stylus">
 @import '~variables'
-.ni-form
-  max-width width-form
-
 .ni-form-group
   padding 0.5rem 1rem
   position relative

--- a/app/src/renderer/components/common/NiPage.vue
+++ b/app/src/renderer/components/common/NiPage.vue
@@ -57,6 +57,7 @@ export default {
   position relative
   display flex
   flex-flow column nowrap
+  max-width width-main-max
 
 .ni-page-title
   color bright

--- a/app/src/renderer/styles/variables.styl
+++ b/app/src/renderer/styles/variables.styl
@@ -51,8 +51,8 @@ danger = hsl(0,100%,55%)
 // sizes
 aw = 64rem
 width-main = 100%
+width-main-max = 64rem
 width-side = 16rem
-width-form = 48rem
 bw = 3*px
 
 //==============================================================================


### PR DESCRIPTION
* sets max width of 1024px on main content area
* I think it still looks a little wide for the Send page, but we can discuss adding two widths for forms -- full width and possibly half width -- in another issue.
* 1024 is a good max for most people scanning horizontally on typical desktop/laptop displays
* looks great on transactions page, proposals page, pages with visible public keys/addresses

![screen shot 2018-01-25 at 2 07 52 pm](https://user-images.githubusercontent.com/172531/35373428-4c301c7a-01d9-11e8-833e-41368a49218b.png)

Closes #297 
