### PR TITLE
Matt/158 - Show error for baseserver init failure

### DIFF
--- a/app/src/renderer/components/common/NiSessionLoading.vue
+++ b/app/src/renderer/components/common/NiSessionLoading.vue
@@ -8,11 +8,8 @@
 </template>
 
 <script>
-import Notifications from '@nylira/vue-notifications'
 import { mapGetters } from 'vuex'
 export default {
-  name: 'ni-session-loading',
-  components: { Notifications },
-  computed: mapGetters(['notifications'])
+  name: 'ni-session-loading'
 }
 </script>

--- a/app/src/renderer/components/common/NiSessionLoading.vue
+++ b/app/src/renderer/components/common/NiSessionLoading.vue
@@ -10,7 +10,6 @@
 <script>
 import Notifications from '@nylira/vue-notifications'
 import { mapGetters } from 'vuex'
-import store from '../../vuex/store'
 export default {
   name: 'ni-session-loading',
   components: { Notifications },

--- a/app/src/renderer/components/common/NiSessionLoading.vue
+++ b/app/src/renderer/components/common/NiSessionLoading.vue
@@ -8,7 +8,6 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
 export default {
   name: 'ni-session-loading'
 }

--- a/app/src/renderer/components/common/NiSessionLoading.vue
+++ b/app/src/renderer/components/common/NiSessionLoading.vue
@@ -2,12 +2,18 @@
 .ni-session: .ni-session-container
   .ni-session-header
     .ni-session-title Loading&hellip;
-  .ni-session-main &nbsp;
+  .ni-session-main &nbsp
   .ni-session-footer &nbsp;
+  notifications(:notifications='notifications' theme='cosmos')
 </template>
 
 <script>
+import Notifications from '@nylira/vue-notifications'
+import { mapGetters } from 'vuex'
+import store from '../../vuex/store'
 export default {
-  name: 'ni-session-loading'
+  name: 'ni-session-loading',
+  components: { Notifications },
+  computed: mapGetters(['notifications'])
 }
 </script>

--- a/app/src/renderer/vuex/modules/node.js
+++ b/app/src/renderer/vuex/modules/node.js
@@ -74,11 +74,19 @@ export default function ({ node }) {
       dispatch('pollRPCConnection')
     },
     async checkConnection ({ commit }) {
+      let error = () => commit('notifyError', {
+        title: 'Critical Error',
+        body: `Couldn't initialize the blockchain client. If the problem persists, please contact Cosmos support.`
+      })
       try {
-        await node.lcdConnected()
-        return true
+        if (await node.lcdConnected()) {
+          return true
+        } else {
+          error()
+          return false
+        }
       } catch (err) {
-        commit('notifyError', {title: 'Critical Error', body: `Couldn't initialize blockchain connector`})
+        error()
         return false
       }
     },

--- a/app/src/renderer/vuex/modules/node.js
+++ b/app/src/renderer/vuex/modules/node.js
@@ -76,7 +76,7 @@ export default function ({ node }) {
     async checkConnection ({ commit }) {
       let error = () => commit('notifyError', {
         title: 'Critical Error',
-        body: `Couldn't initialize the blockchain client. If the problem persists, please contact Cosmos support.`
+        body: `Couldn't initialize the blockchain client. If the problem persists, please make an issue on GitHub.`
       })
       try {
         if (await node.lcdConnected()) {

--- a/test/unit/specs/components/common/__snapshots__/NISessionLoading.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/NISessionLoading.spec.js.snap
@@ -14,6 +14,7 @@ exports[`NiSessionLoading has the expected html structure 1`] = `
 <div class=\\"ni-session-footer\\">
    &nbsp;
 </div>
+<notifications theme=\\"cosmos\\"></notifications>
 </div>
 </div>"
 `;


### PR DESCRIPTION
Closes #158 

In the case that baseserver fails to start up (rare, but has happened occasionally when the data directory was corrupted), we now show an error notification which stays present in the window. It could look better, but I'm not expecting this to happen much in the wild.

![](https://i.imgur.com/zXFTBvA.png)