### PR TITLE
Matt/348 - Native menu bar

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-let { app, BrowserWindow, Menu } = require('electron')
+let { app, BrowserWindow } = require('electron')
 let fs = require('fs-extra')
 let { join } = require('path')
 let { spawn } = require('child_process')
@@ -12,6 +12,7 @@ let toml = require('toml')
 let axios = require('axios')
 let pkg = require('../../../package.json')
 let relayServer = require('./relayServer.js')
+let addMenu = require('./menu.js')
 
 let started = false
 let shuttingDown = false
@@ -139,7 +140,7 @@ function createWindow () {
   webContents.on('will-navigate', handleRedirect)
   webContents.on('new-window', handleRedirect)
 
-  Menu.setApplicationMenu(null)
+  if (!WIN) addMenu()
 }
 
 function startProcess (name, args, env) {

--- a/app/src/main/menu.js
+++ b/app/src/main/menu.js
@@ -15,7 +15,7 @@ module.exports = function () {
       submenu: [
         { label: 'Cut', accelerator: 'CmdOrCtrl+X', selector: 'cut:' },
         { label: 'Copy', accelerator: 'CmdOrCtrl+C', selector: 'copy:' },
-        { label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:' },
+        { label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:' }
       ]
     }
   ]

--- a/app/src/main/menu.js
+++ b/app/src/main/menu.js
@@ -9,6 +9,14 @@ module.exports = function () {
         { type: 'separator' },
         { label: 'Quit', accelerator: 'Command+Q', click: () => app.quit() }
       ]
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        { label: 'Cut', accelerator: 'CmdOrCtrl+X', selector: 'cut:' },
+        { label: 'Copy', accelerator: 'CmdOrCtrl+C', selector: 'copy:' },
+        { label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:' },
+      ]
     }
   ]
 

--- a/app/src/main/menu.js
+++ b/app/src/main/menu.js
@@ -1,0 +1,17 @@
+const { app, Menu } = require('electron')
+
+module.exports = function () {
+  let template = [
+    {
+      label: 'Cosmos',
+      submenu: [
+        { label: 'About Cosmos UI', selector: 'orderFrontStandardAboutPanel:' },
+        { type: 'separator' },
+        { label: 'Quit', accelerator: 'Command+Q', click: () => app.quit() }
+      ]
+    }
+  ]
+
+  let menu = Menu.buildFromTemplate(template)
+  Menu.setApplicationMenu(menu)
+}


### PR DESCRIPTION
Closes #348 

Puts the native menu bar back in.

Currently disabled on Windows, since Fabo said he liked not having it. Although I think I remember there's a convention on Windows to enable it when pressing `alt`?

Right now it's pretty bare, just adding the `About Cosmos UI` menu option, and `Edit` since that's how some users would probably like to copy addresses. Should we add some more just so it looks more complete, like `Window`, `Help`, etc?

Before:
![](https://i.imgur.com/Undi4eK.png)

After:
![](https://puu.sh/z9ptm/71d4d0d6fd.png)