### PR TITLE
Peng/389 release 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 * Added a callback and console output when Vue app has finished loading to test build apps on successful startup. @faboweb
-* Resolved notifications error on NiSessionLoading.vue @nylira.
-* Resolved old saved prevAccountKey being used in NiSessionSignIn.vue @nylira.
-* Improved performance of amountBonded in LiDelegate.vue @nylira.
-* Prevented user from going to PageBond if they don't have any atoms/fermions @nylira.
-* Hid the bonding interface on PageDelegates if the user doesn't have any atoms @nylira.
+* Resolved notifications error on NiSessionLoading.vue. @nylira
+* Resolved old saved prevAccountKey being used in NiSessionSignIn.vue. @nylira
+* Improved performance of amountBonded in LiDelegate.vue./ @nylira
+* Prevented user from going to PageBond if they don't have any atoms. @nylira
+* Hid the bonding interface on PageDelegates if the user doesn't have any atoms. @nylira
 * Improved error handling by shutting down the application when the are unhandled errors in the main thread. @faboweb
+
+## [0.4.0] - 2018-01-31
+### Added
+* Added release documentation. @mappum
+
+### Changed
+* Updated app version to 0.4.0 in `package.json`
+* Updated release script to use `tar-fs` instead of `tar-stream` to support symlinks. @nylira
+
+### Removed
+* Removed unused `sass-loader` node dependency. @nylira

--- a/app/src/renderer/components/common/AppMenu.vue
+++ b/app/src/renderer/components/common/AppMenu.vue
@@ -4,7 +4,7 @@ menu.app-menu
     list-item(to="/" exact @click.native="close" title="Balances")
     list-item(to="/wallet/transactions" exact @click.native="close" title="Transactions")
     list-item(to="/staking" exact @click.native="close" title="Delegates")
-    list-item(to="/validators" exact @click.native="close" title="Validators" v-bind:class="{ 'active': isValidatorPage }")
+    list-item(to="/validators" exact @click.native="close" title="Validators" v-bind:class="{ 'active': isValidatorPage }" v-if="config.devMode")
     list-item(to="/proposals" exact @click.native="close" title="Proposals" v-if="config.devMode")
     list-item(to="/blocks" exact @click.native="close" title="Blocks")
     connectivity

--- a/app/src/renderer/components/common/NiModalHelp.vue
+++ b/app/src/renderer/components/common/NiModalHelp.vue
@@ -1,10 +1,7 @@
 <template lang="pug">
 modal.ni-modal-help(v-if="active" :close="close")
   div(slot='title') Need Help?
-  p Is something in the app not working correctly? Talk to us on our forum, developer chat, or create an issue on our GitHub. Thanks for improving Cosmos!
-  list-item(
-    title="Cosmos Forum"
-    href="https://forum.cosmos.network")
+  p Something in the app not working correctly? Tell us what went wrong in developer chat or create an issue on our GitHub. Thanks for improving Cosmos!
   list-item(
     title="Developer Chat"
     href="https://riot.im/app/#/room/#cosmos:matrix.org")

--- a/app/src/renderer/components/common/NiSession.vue
+++ b/app/src/renderer/components/common/NiSession.vue
@@ -32,11 +32,6 @@ export default {
   },
   computed: {
     ...mapGetters(['config'])
-  },
-  beforeDestroy () {
-    if (!this.config.devMode) {
-      this.$store.commit('setModalSession', true)
-    }
   }
 }
 </script>

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "Cosmos",
   "productName": "Cosmos",
-  "version": "0.3.0",
-  "description": "The electron wrapper for Cosmos UI.",
+  "version": "0.4.0",
+  "description": "The electron-based user interface for Cosmos Network.",
   "author": "All In Bits, Inc <hello@tendermint.com>",
   "license": "Apache-2.0",
   "homepage": "https://cosmos.network",
@@ -75,7 +75,6 @@
     "numeral": "^2.0.6",
     "proxyquire": "^1.8.0",
     "pug": "^2.0.0-rc.1",
-    "sass-loader": "^6.0.6",
     "spectron": "^3.7.2",
     "style-loader": "^0.19.1",
     "tape": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "style-loader": "^0.19.1",
     "tape": "^4.8.0",
     "tape-promise": "^2.0.1",
+    "tar-fs": "^1.16.0",
     "tree-kill": "^1.1.0",
     "url-loader": "^0.6.2",
     "vue-hot-reload-api": "^2.0.7",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "style-loader": "^0.19.1",
     "tape": "^4.8.0",
     "tape-promise": "^2.0.1",
-    "tar-fs": "^1.16.0",
+    "tar-stream": "^1.5.5",
     "tree-kill": "^1.1.0",
     "url-loader": "^0.6.2",
     "vue-hot-reload-api": "^2.0.7",

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -156,7 +156,12 @@ function tarFolder (inDir, outDir, version) {
         files
         .filter(file => !fs.lstatSync(file).isDirectory())
         .forEach(file => {
-          pack.entry({ name: path.relative(inDir, file) }, fs.readFileSync(file))
+          try {
+            pack.entry({ name: path.relative(inDir, file) }, fs.readFileSync(file))
+          } catch (err) {
+            console.warning(`Couldn't pack file`, file)
+            // skip this file
+          }
         })
         pack.finalize()
         resolve()

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -159,7 +159,7 @@ function tarFolder (inDir, outDir, version) {
           try {
             pack.entry({ name: path.relative(inDir, file) }, fs.readFileSync(file))
           } catch (err) {
-            console.warning(`Couldn't pack file`, file)
+            console.warning(`Couldn't pack file`, file, err)
             // skip this file
           }
         })

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -159,7 +159,7 @@ function tarFolder (inDir, outDir, version) {
           try {
             pack.entry({ name: path.relative(inDir, file) }, fs.readFileSync(file))
           } catch (err) {
-            console.warning(`Couldn't pack file`, file, err)
+            console.error(`Couldn't pack file`, file, err)
             // skip this file
           }
         })

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -9,7 +9,7 @@ var glob = require('glob')
 var JSZip = require('jszip')
 const zlib = require('zlib')
 var deterministic = require('deterministic-tar')
-var tar = require('tar-stream')
+var tar = require('tar-fs')
 const packageJson = require('../package.json')
 
 let skipPack = false
@@ -145,26 +145,9 @@ function tarFolder (inDir, outDir, version) {
   return new Promise(async (resolve, reject) => {
     let name = path.parse(inDir).name
     let outFile = path.join(outDir, `${name}_${version}.tar.gz`)
-    var pack = tar.pack()
-
-    await new Promise((resolve) => {
-      glob(inDir + '/**/*', (err, files) => {
-        if (err) {
-          return reject(err)
-        }
-        // add files to tar
-        files
-        .filter(file => !fs.lstatSync(file).isDirectory())
-        .forEach(file => {
-          pack.entry({ name: path.relative(inDir, file) }, fs.readFileSync(file))
-        })
-        pack.finalize()
-        resolve()
-      })
-    })
 
     // make tar deterministic
-    pack
+    tar.pack(inDir)
     .pipe(deterministic())
     .pipe(zlib.createGzip())
     // save tar to disc

--- a/test/unit/specs/components/common/__snapshots__/NiModalHelp.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/NiModalHelp.spec.js.snap
@@ -32,50 +32,8 @@ exports[`NiModalHelp has the expected html structure 1`] = `
       class="ni-modal-main"
     >
       <p>
-        Is something in the app not working correctly? Talk to us on our forum, developer chat, or create an issue on our GitHub. Thanks for improving Cosmos!
+        Something in the app not working correctly? Tell us what went wrong in developer chat or create an issue on our GitHub. Thanks for improving Cosmos!
       </p>
-      <a
-        class="ni-li ni-li-link proposal-enter proposal-enter-active"
-        href="https://forum.cosmos.network"
-      >
-        <div
-          class="ni-li-container"
-        >
-          <div
-            class="ni-li-thumb"
-          >
-            <!---->
-          </div>
-          <div
-            class="ni-li-label"
-          >
-            <div
-              class="ni-li-title"
-            >
-              Cosmos Forum
-            </div>
-            <div
-              class="ni-li-subtitle"
-            >
-              
-            </div>
-          </div>
-          <div
-            class="ni-li-icon"
-          >
-            <i
-              class="material-icons inactive"
-            >
-              chevron_right
-            </i>
-            <i
-              class="material-icons active"
-            >
-              my_location
-            </i>
-          </div>
-        </div>
-      </a>
       <a
         class="ni-li ni-li-link proposal-enter proposal-enter-active"
         href="https://riot.im/app/#/room/#cosmos:matrix.org"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,13 +86,7 @@ let config = {
   resolveLoader: {
     root: path.join(__dirname, 'node_modules')
   },
-  target: 'electron-renderer',
-  vue: {
-    loaders: {
-      sass: 'vue-style-loader!css-loader!sass-loader?indentedSyntax=1',
-      scss: 'vue-style-loader!css-loader!sass-loader'
-    }
-  }
+  target: 'electron-renderer'
 }
 
 if (process.env.NODE_ENV !== 'production') {

--- a/webpack.renderer.config.js
+++ b/webpack.renderer.config.js
@@ -48,13 +48,7 @@ let rendererConfig = {
       {
         test: /\.vue$/,
         use: {
-          loader: 'vue-loader',
-          options: {
-            loaders: {
-              sass: 'vue-style-loader!css-loader!sass-loader?indentedSyntax=1',
-              scss: 'vue-style-loader!css-loader!sass-loader'
-            }
-          }
+          loader: 'vue-loader'
         }
       },
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1559,10 +1559,6 @@ chokidar@^2.0.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chownr@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
-
 chromium-pickle-js@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz#04a106672c18b085ab774d983dfa3ea138f22205"
@@ -6589,13 +6585,6 @@ pug@^2.0.0-rc.1:
     pug-runtime "^2.0.3"
     pug-strip-comments "^1.0.2"
 
-pump@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.3.tgz#5dfe8311c33bbf6fc18261f9f34702c47c08a954"
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
-
 pump@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
@@ -7851,15 +7840,6 @@ tape@^4.8.0:
     string.prototype.trim "~1.1.2"
     through "~2.3.8"
 
-tar-fs@^1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.16.0.tgz#e877a25acbcc51d8c790da1c57c9cf439817b896"
-  dependencies:
-    chownr "^1.0.1"
-    mkdirp "^0.5.1"
-    pump "^1.0.0"
-    tar-stream "^1.1.2"
-
 tar-pack@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
@@ -7873,7 +7853,7 @@ tar-pack@^3.4.0:
     tar "^2.2.1"
     uid-number "^0.0.6"
 
-tar-stream@^1.1.2, tar-stream@^1.5.0:
+tar-stream@^1.5.0, tar-stream@^1.5.5:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.5.tgz#5cad84779f45c83b1f2508d96b09d88c7218af55"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1559,6 +1559,10 @@ chokidar@^2.0.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
+chownr@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
+
 chromium-pickle-js@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz#04a106672c18b085ab774d983dfa3ea138f22205"
@@ -6585,6 +6589,13 @@ pug@^2.0.0-rc.1:
     pug-runtime "^2.0.3"
     pug-strip-comments "^1.0.2"
 
+pump@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.3.tgz#5dfe8311c33bbf6fc18261f9f34702c47c08a954"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 pump@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
@@ -7840,6 +7851,15 @@ tape@^4.8.0:
     string.prototype.trim "~1.1.2"
     through "~2.3.8"
 
+tar-fs@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.16.0.tgz#e877a25acbcc51d8c790da1c57c9cf439817b896"
+  dependencies:
+    chownr "^1.0.1"
+    mkdirp "^0.5.1"
+    pump "^1.0.0"
+    tar-stream "^1.1.2"
+
 tar-pack@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
@@ -7853,7 +7873,7 @@ tar-pack@^3.4.0:
     tar "^2.2.1"
     uid-number "^0.0.6"
 
-tar-stream@^1.5.0:
+tar-stream@^1.1.2, tar-stream@^1.5.0:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.5.tgz#5cad84779f45c83b1f2508d96b09d88c7218af55"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,7 +350,7 @@ async@^1.4.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.0.0, async@^2.1.2, async@^2.1.4, async@^2.1.5, async@^2.4.1:
+async@^2.0.0, async@^2.1.2, async@^2.1.4, async@^2.4.1:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
@@ -1637,15 +1637,6 @@ cliui@^3.2.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
-
-clone-deep@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-0.3.0.tgz#348c61ae9cdbe0edfe053d91ff4cc521d790ede8"
-  dependencies:
-    for-own "^1.0.0"
-    is-plain-object "^2.0.1"
-    kind-of "^3.2.2"
-    shallow-clone "^0.1.2"
 
 clone@^1.0.2:
   version "1.0.3"
@@ -3258,10 +3249,6 @@ for-each@~0.3.2:
   dependencies:
     is-function "~1.0.0"
 
-for-in@^0.1.3:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
-
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -3269,12 +3256,6 @@ for-in@^1.0.1, for-in@^1.0.2:
 for-own@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
-  dependencies:
-    for-in "^1.0.1"
-
-for-own@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/for-own/-/for-own-1.0.0.tgz#c63332f415cedc4b04dbfe70cf836494c53cb44b"
   dependencies:
     for-in "^1.0.1"
 
@@ -4074,7 +4055,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.0.2, is-buffer@^1.1.5:
+is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
@@ -4831,13 +4812,7 @@ killable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.0.tgz#da8b84bd47de5395878f95d64d02f2449fe05e6b"
 
-kind-of@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"
-  dependencies:
-    is-buffer "^1.0.2"
-
-kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^3.2.2:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   dependencies:
@@ -4862,10 +4837,6 @@ klaw@^1.0.0:
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
   optionalDependencies:
     graceful-fs "^4.1.9"
-
-lazy-cache@^0.2.3:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-0.2.7.tgz#7feddf2dcb6edb77d11ef1d117ab5ffdf0ab1b65"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -4951,7 +4922,7 @@ loader-utils@^0.2.16, loader-utils@~0.2.5:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0:
+loader-utils@^1.0.2, loader-utils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
   dependencies:
@@ -5132,10 +5103,6 @@ lodash.pairs@^3.0.0:
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-
-lodash.tail@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
 
 lodash.toplainobject@^3.0.0:
   version "3.0.0"
@@ -5402,13 +5369,6 @@ mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
-
-mixin-object@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/mixin-object/-/mixin-object-2.0.1.tgz#4fb949441dab182540f1fe035ba60e1947a5e57e"
-  dependencies:
-    for-in "^0.1.3"
-    is-extendable "^0.1.1"
 
 mkdirp@0.5.0:
   version "0.5.0"
@@ -7185,16 +7145,6 @@ sass-graph@^2.2.4:
     scss-tokenizer "^0.2.3"
     yargs "^7.0.0"
 
-sass-loader@^6.0.6:
-  version "6.0.6"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-6.0.6.tgz#e9d5e6c1f155faa32a4b26d7a9b7107c225e40f9"
-  dependencies:
-    async "^2.1.5"
-    clone-deep "^0.3.0"
-    loader-utils "^1.0.1"
-    lodash.tail "^4.1.1"
-    pify "^3.0.0"
-
 sax@0.5.x:
   version "0.5.8"
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
@@ -7343,15 +7293,6 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
-
-shallow-clone@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-0.1.2.tgz#5909e874ba77106d73ac414cfec1ffca87d97060"
-  dependencies:
-    is-extendable "^0.1.1"
-    kind-of "^2.0.1"
-    lazy-cache "^0.2.3"
-    mixin-object "^2.0.1"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
* Resolves symlinks not being included in `tar.gz` by using `tar-fs` instead of `tar-stream`
* Updates version to 0.4.0
* Created Gaia binaries: download them from the pinned files on the #dev-gaia channel or build them yourself.

**Please follow [the release docs](https://github.com/cosmos/cosmos-ui/blob/peng/389-release-0-4/docs/release.md) and confirm these hashes for me: WIP**

Closes #389