### PR TITLE
calculating splash styles with variables

### DIFF
--- a/app/index.ejs
+++ b/app/index.ejs
@@ -21,46 +21,5 @@
 </div>
 
 <style>
-body { margin: 0; }
-#load {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100vw;
-  height: 100vh;
-  background: hsl(233, 36%, 13%);
-}
-#load-container {
-  font: 16px/1.5 system, -apple-system, BlinkMacSystemFont, "Roboto", "Seogue UI", "Helvetica Neue", "Lucida Grande", sans-serif;
-  margin: 0 auto;
-  width: 18rem;
-  display: flex;
-  flex-flow: column nowrap;
-  justify-content: center;
-  box-sizing: border-box;
-}
-#load-title {
-  font-size: 1.5rem;
-  font-weight: 600;
-  line-height: 1;
-  text-transform: uppercase;
-  letter-spacing: 0.25rem;
-  color: #fff;
-  margin-bottom: 1rem;
-  padding: 0 0.5rem;
-}
-
-#load-main p {
-  font-size: 1rem;
-  line-height: 2rem;
-  font-weight: 300;
-  padding: 0 0.5rem;
-  color: hsl(226, 13%, 50%);
-  background: hsl(233, 33%, 16%);
-  margin: 0 0 1px;
-}
-#load-main a {
-  text-decoration: none;
-  color: hsl(233, 96%, 70%);
-}
+<%= htmlWebpackPlugin.options.styles %>
 </style>

--- a/app/src/renderer/styles/index.styl
+++ b/app/src/renderer/styles/index.styl
@@ -1,0 +1,42 @@
+body { margin: 0; }
+#load {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100vw;
+  height: 100vh;
+  background: app-bg;
+}
+#load-container {
+  font: 16px/1.5 system, -apple-system, BlinkMacSystemFont, "Roboto", "Seogue UI", "Helvetica Neue", "Lucida Grande", sans-serif;
+  margin: 0 auto;
+  width: 18rem;
+  display: flex;
+  flex-flow: column nowrap;
+  justify-content: center;
+  box-sizing: border-box;
+}
+#load-title {
+  font-size: h2;
+  font-weight: 600;
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.25rem;
+  color: bright;
+  margin-bottom: 1rem;
+  padding: 0 0.5rem;
+}
+
+#load-main p {
+  font-size: m;
+  line-height: 2rem;
+  font-weight: 300;
+  padding: 0 0.5rem;
+  color: dim;
+  background: app-fg;
+  margin: 0 0 1px;
+}
+#load-main a {
+  text-decoration: none;
+  color: link;
+}

--- a/webpack.renderer.config.js
+++ b/webpack.renderer.config.js
@@ -5,6 +5,8 @@ process.env.BABEL_ENV = 'renderer'
 const path = require('path')
 const settings = require('./config.js')
 const webpack = require('webpack')
+const stylus = require('stylus')
+const fs = require('fs-extra')
 
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
@@ -87,7 +89,8 @@ let rendererConfig = {
       template: './app/index.ejs',
       appModules: process.env.NODE_ENV !== 'production'
         ? path.resolve(__dirname, 'app/node_modules')
-        : false
+        : false,
+      styles: stylus(fs.readFileSync('./app/src/renderer/styles/index.styl', 'utf8')).import('./app/src/renderer/styles/variables.styl').render()
     }),
     new webpack.NoEmitOnErrorsPlugin(),
     // warnings caused by websocket-stream, which has a server-part that is unavailable on the the client


### PR DESCRIPTION
implements #130

I replaced the existing colors and some sizes with the variables available. Those where no 100% match so I post the comparison below.

Before:
![image](https://user-images.githubusercontent.com/5869273/35698532-9daec178-078d-11e8-9bee-c17d7bf9da74.png)

After:
![image](https://user-images.githubusercontent.com/5869273/35698556-afa18fdc-078d-11e8-8b88-f0077391401c.png)

One thing: I couldn't replace the font-family with the one from the variables (sans). If I do I get following output:
![image](https://user-images.githubusercontent.com/5869273/35698846-90c2e34e-078e-11e8-9e83-b4a568099c29.png)

Which one is the correct one? (maybe @nylira)