### PR TITLE
Add code coverage upload to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,4 +32,4 @@ jobs:
       - run: yarn lint
       - run: yarn run test
     post:
-      - bash <(curl -s https://codecov.io/bash)
+      - bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 jobs:
-  test:
+  build:
     docker:
       # specify the version you desire here
       - image: circleci/node:9.4.0-browsers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 jobs:
-  build:
+  test:
     docker:
       # specify the version you desire here
       - image: circleci/node:9.4.0-browsers
@@ -12,8 +12,6 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - run: sudo npm i -g codeclimate-test-reporter
-
       - checkout
 
       # Download and cache dependencies
@@ -33,4 +31,5 @@ jobs:
         
       - run: yarn lint
       - run: yarn run test
-      - run: codeclimate-test-reporter < test/unit/coverage/lcov.info
+    post:
+      - bash <(curl -s https://codecov.io/bash)

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,19 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default: on
+    patch:
+      default: on
+    changes:
+      default: off
+
+comment:
+  layout: "header, reach, diff, flags, files, footer"
+  behavior: default
+  require_changes: no
+  require_base: no
+  require_head: yes


### PR DESCRIPTION
This should add the test coverage reports to https://codecov.io/gh/cosmos/cosmos-ui. When this is done, I want to enable a soft check in PRs that shows us if the test-coverage got up or down. This helps me to reconsider my PRs from time to time.