### PR TITLE
Fix 0.4.0 crashing on windows

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -10,6 +10,8 @@ let semver = require('semver')
 let event = require('event-to-promise')
 let toml = require('toml')
 let axios = require('axios')
+var glob = require('glob')
+
 let pkg = require('../../../package.json')
 let relayServer = require('./relayServer.js')
 let addMenu = require('./menu.js')
@@ -273,11 +275,25 @@ async function backupData (root) {
   } while (exists(path))
 
   log(`backing up data to "${path}"`)
+
+  // ATTENTION: mainLog stream is still open at this point, so we can't move it arround (at least on windows)
   fs.copySync(root, path, {
     overwrite: false,
-    errorOnExist: true
+    errorOnExist: true,
+    filter: file => file.indexOf('main.log') === -1
   })
-  await fs.remove(root)
+  await new Promise((resolve, reject) => {
+    glob(root + '/**/*', (err, files) => {
+      if (err) {
+        return reject(err)
+      }
+
+      files
+      .filter(file => file.indexOf('main.log') === -1)
+      .forEach(file => fs.removeSync(file))
+      resolve()
+    })
+  })
 }
 
 /*

--- a/test/unit/specs/main.spec.js
+++ b/test/unit/specs/main.spec.js
@@ -277,6 +277,28 @@ describe('Startup Process', () => {
 
       expect(fs.existsSync(testRoot.substr(0, testRoot.length - 1) + '_backup_1/genesis.json')).toBe(true)
     })
+
+    it('should not backup main log', async function () {
+      expect(fs.existsSync(testRoot.substr(0, testRoot.length - 1) + '_backup_1/genesis.json')).toBe(true)
+    })
+  })
+
+  describe('Keep main log on update', function () {
+    mainSetup()
+
+    it('should not backup main log', async function () {
+      resetModulesKeepingFS()
+      fs.writeFile(testRoot + 'main.log', 'I AM A LOGFILE')
+
+      // alter the version so the main thread assumes an update
+      jest.mock(root + 'package.json', () => ({
+        version: '1.1.1'
+      }))
+      await require(appRoot + 'src/main/index.js')
+
+      expect(fs.existsSync(testRoot.substr(0, testRoot.length - 1) + '_backup_1/main.log')).toBe(false)
+      expect(fs.readFileSync(testRoot + 'main.log')).toContain('I AM A LOGFILE')
+    })
   })
 
   describe('Update genesis.json', function () {


### PR DESCRIPTION
fixes: #436 

Fixes an issue with backing up the config folder while there is still an active stream to main.log. main.log is now not copied anymore. It stays in the root folder.