### PR TITLE
Upgrade to js-tendermint@2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "stacktrace-js": "^2.0.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
-    "tendermint": "2.0.5",
+    "tendermint": "^2.0.5",
     "tendermint-crypto": "github:mappum/js-crypto",
     "toml": "^2.3.3",
     "user-home": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "stacktrace-js": "^2.0.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
-    "tendermint": "2.0.3",
+    "tendermint": "2.0.5",
     "tendermint-crypto": "github:mappum/js-crypto",
     "toml": "^2.3.3",
     "user-home": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -406,7 +406,7 @@ axios@^0.16.2:
     follow-redirects "^1.2.3"
     is-buffer "^1.1.5"
 
-axios@^0.17.0:
+axios@^0.17.0, axios@^0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.17.1.tgz#2d8e3e5d0bdbd7327f91bc814f5c57660f81824d"
   dependencies:
@@ -7889,10 +7889,11 @@ tar@^2.0.0, tar@^2.2.1:
     supercop.js "^2.0.1"
     varstruct "^5.3.0"
 
-tendermint@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/tendermint/-/tendermint-2.0.3.tgz#6afef653622b351455591115b43db8e845e95972"
+tendermint@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/tendermint/-/tendermint-2.0.5.tgz#681014ea04c77f36b8dbaed2e3c430e4a24d6cbc"
   dependencies:
+    axios "^0.17.1"
     browser-request "^0.3.3"
     camelcase "^4.0.0"
     ndjson "^1.5.0"


### PR DESCRIPTION
Upgrades the dependency of the `tendermint` npm package since we fixed the issues from 2.0.4 (we previously had to downgrade to 2.0.3).